### PR TITLE
Feature/unified db2type mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,64 @@ builder.Services
 
 All registration methods validate their arguments. Passing a `null` service collection throws `ArgumentNullException`; passing a `null`, empty, or whitespace connection string throws `ArgumentException`.
 
+## Cross-Platform Data Types
+
+The library provides a platform-agnostic `Db2Type` enum that is automatically mapped at runtime to the correct platform-specific type (`WinDb2Type` on Windows, `LnxDb2Type` on Linux/macOS). This allows you to write code that works on any OS without `#if` directives or platform checks.
+
+### Available types
+
+| Db2Type | Windows (OleDb) | Linux (IBM.Data.Db2) |
+|---|---|---|
+| `SmallInt` | `SmallInt` | `SmallInt` |
+| `Integer` | `Integer` | `Integer` |
+| `BigInt` | `BigInt` | `BigInt` |
+| `Real` | `Single` | `Real` |
+| `Double` | `Double` | `Double` |
+| `Decimal` | `Decimal` | `Decimal` |
+| `Numeric` | `Numeric` | `Numeric` |
+| `Char` | `Char` | `Char` |
+| `VarChar` | `VarChar` | `VarChar` |
+| `LongVarChar` | `LongVarChar` | `LongVarChar` |
+| `Binary` | `Binary` | `Binary` |
+| `VarBinary` | `VarBinary` | `VarBinary` |
+| `LongVarBinary` | `LongVarBinary` | `LongVarBinary` |
+| `Date` | `DBDate` | `Date` |
+| `Time` | `DBTime` | `Time` |
+| `Timestamp` | `DBTimeStamp` | `Timestamp` |
+| `Clob` | `LongVarWChar` | `Clob` |
+| `Blob` | `LongVarBinary` | `Blob` |
+| `Xml` | `LongVarWChar` | `Xml` |
+| `Boolean` | `Boolean` | `Boolean` |
+
+### Example: write-once, run-anywhere
+
+Use `AddDb2Services` for automatic platform detection and `Db2Type` for parameters — the same code deploys to Windows, Linux, and macOS without changes:
+
+``` csharp
+public class Db2Repository(IDb2Connection connection)
+{
+    public async Task DoSomething(string param1, int param2)
+    {
+        using (connection)
+        {
+            await connection.Open();
+
+            using var cmd = connection.CreateCommand("STORED_PROCEDURE_NAME", CommandType.StoredProcedure);
+
+            cmd.AddParam("@PARAM1", Db2Type.VarChar, 10, param1);
+            cmd.AddParam("@PARAM2", Db2Type.Decimal, 6, param2);
+            cmd.AddParam("@OUTPARAM", Db2Type.VarChar, 250, ParameterDirection.Output);
+
+            await cmd.ExecuteNonQuery();
+
+            string? outputResult = cmd.ReadParam("@OUTPARAM") as string;
+        }
+    }
+}
+```
+
+You can still use the platform-specific types (`WinDb2Type`, `LnxDb2Type`) directly when you need access to types that don't have a cross-platform equivalent.
+
 ## Usage on Windows
 
 Inject `IWinDb2Connection` into your repository or service class through constructor injection.
@@ -264,11 +322,11 @@ public class Db2Repository(ILnxDb2Connection connection)
 
 ## Supported Platforms
 
-| Operating System | Driver | Interface | Type Enum |
-|---|---|---|---|
-| Windows | System.Data.OleDb | `IWinDb2Connection` | `WinDb2Type` |
-| Linux | IBM.Data.Db2 | `ILnxDb2Connection` | `LnxDb2Type` |
-| macOS | IBM.Data.Db2 | `ILnxDb2Connection` | `LnxDb2Type` |
+| Operating System | Driver | Interface | Platform Type | Cross-Platform Type |
+|---|---|---|---|---|
+| Windows | System.Data.OleDb | `IWinDb2Connection` | `WinDb2Type` | `Db2Type` |
+| Linux | IBM.Data.Db2 | `ILnxDb2Connection` | `LnxDb2Type` | `Db2Type` |
+| macOS | IBM.Data.Db2 | `ILnxDb2Connection` | `LnxDb2Type` | `Db2Type` |
 
 ## Architecture Overview
 

--- a/src/Ninja.Sharp.OpenDb2.Tests/Db2TypeMapperTests.cs
+++ b/src/Ninja.Sharp.OpenDb2.Tests/Db2TypeMapperTests.cs
@@ -1,0 +1,84 @@
+// (c) 2024 thesharpninjas
+// This code is licensed under MIT license (see LICENSE.txt for details)
+
+using OpenDb2.Enums;
+
+namespace Ninja.Sharp.OpenDb2.Tests
+{
+    public class Db2TypeMapperTests
+    {
+        [Theory]
+        [InlineData(Db2Type.SmallInt, WinDb2Type.SmallInt)]
+        [InlineData(Db2Type.Integer, WinDb2Type.Integer)]
+        [InlineData(Db2Type.BigInt, WinDb2Type.BigInt)]
+        [InlineData(Db2Type.Real, WinDb2Type.Single)]
+        [InlineData(Db2Type.Double, WinDb2Type.Double)]
+        [InlineData(Db2Type.Decimal, WinDb2Type.Decimal)]
+        [InlineData(Db2Type.Numeric, WinDb2Type.Numeric)]
+        [InlineData(Db2Type.Char, WinDb2Type.Char)]
+        [InlineData(Db2Type.VarChar, WinDb2Type.VarChar)]
+        [InlineData(Db2Type.LongVarChar, WinDb2Type.LongVarChar)]
+        [InlineData(Db2Type.Binary, WinDb2Type.Binary)]
+        [InlineData(Db2Type.VarBinary, WinDb2Type.VarBinary)]
+        [InlineData(Db2Type.LongVarBinary, WinDb2Type.LongVarBinary)]
+        [InlineData(Db2Type.Date, WinDb2Type.DBDate)]
+        [InlineData(Db2Type.Time, WinDb2Type.DBTime)]
+        [InlineData(Db2Type.Timestamp, WinDb2Type.DBTimeStamp)]
+        [InlineData(Db2Type.Clob, WinDb2Type.LongVarWChar)]
+        [InlineData(Db2Type.Blob, WinDb2Type.LongVarBinary)]
+        [InlineData(Db2Type.Xml, WinDb2Type.LongVarWChar)]
+        [InlineData(Db2Type.Boolean, WinDb2Type.Boolean)]
+        public void ToWindows_Should_Map_Correctly(Db2Type input, WinDb2Type expected)
+        {
+            var result = Db2TypeMapper.ToWindows(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(Db2Type.SmallInt, LnxDb2Type.SmallInt)]
+        [InlineData(Db2Type.Integer, LnxDb2Type.Integer)]
+        [InlineData(Db2Type.BigInt, LnxDb2Type.BigInt)]
+        [InlineData(Db2Type.Real, LnxDb2Type.Real)]
+        [InlineData(Db2Type.Double, LnxDb2Type.Double)]
+        [InlineData(Db2Type.Decimal, LnxDb2Type.Decimal)]
+        [InlineData(Db2Type.Numeric, LnxDb2Type.Numeric)]
+        [InlineData(Db2Type.Char, LnxDb2Type.Char)]
+        [InlineData(Db2Type.VarChar, LnxDb2Type.VarChar)]
+        [InlineData(Db2Type.LongVarChar, LnxDb2Type.LongVarChar)]
+        [InlineData(Db2Type.Binary, LnxDb2Type.Binary)]
+        [InlineData(Db2Type.VarBinary, LnxDb2Type.VarBinary)]
+        [InlineData(Db2Type.LongVarBinary, LnxDb2Type.LongVarBinary)]
+        [InlineData(Db2Type.Date, LnxDb2Type.Date)]
+        [InlineData(Db2Type.Time, LnxDb2Type.Time)]
+        [InlineData(Db2Type.Timestamp, LnxDb2Type.Timestamp)]
+        [InlineData(Db2Type.Clob, LnxDb2Type.Clob)]
+        [InlineData(Db2Type.Blob, LnxDb2Type.Blob)]
+        [InlineData(Db2Type.Xml, LnxDb2Type.Xml)]
+        [InlineData(Db2Type.Boolean, LnxDb2Type.Boolean)]
+        public void ToLinux_Should_Map_Correctly(Db2Type input, LnxDb2Type expected)
+        {
+            var result = Db2TypeMapper.ToLinux(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void All_Db2Type_Values_Should_Have_Windows_Mapping()
+        {
+            foreach (var type in Enum.GetValues<Db2Type>())
+            {
+                var exception = Record.Exception(() => Db2TypeMapper.ToWindows(type));
+                Assert.Null(exception);
+            }
+        }
+
+        [Fact]
+        public void All_Db2Type_Values_Should_Have_Linux_Mapping()
+        {
+            foreach (var type in Enum.GetValues<Db2Type>())
+            {
+                var exception = Record.Exception(() => Db2TypeMapper.ToLinux(type));
+                Assert.Null(exception);
+            }
+        }
+    }
+}

--- a/src/Ninja.Sharp.OpenDb2.Tests/EnvironmentDetectorTests.cs
+++ b/src/Ninja.Sharp.OpenDb2.Tests/EnvironmentDetectorTests.cs
@@ -1,0 +1,33 @@
+// (c) 2024 thesharpninjas
+// This code is licensed under MIT license (see LICENSE.txt for details)
+
+using Ninja.Sharp.OpenDb2.Interfaces;
+using Ninja.Sharp.OpenDb2.Tests.Attribute;
+using Ninja.Sharp.OpenDb2.Utilities;
+using System.Runtime.InteropServices;
+
+namespace Ninja.Sharp.OpenDb2.Tests
+{
+    public class EnvironmentDetectorTests
+    {
+        private readonly IEnvironmentDetector _detector = new EnvironmentDetector();
+
+        [WindowsOnlyFact]
+        public void GetCurrentOSPlatform_Should_Return_Windows_On_Windows()
+        {
+            Assert.Equal(OSPlatform.Windows, _detector.GetCurrentOSPlatform());
+        }
+
+        [WindowsOnlyFact]
+        public void IsWindows_Should_Return_True_On_Windows()
+        {
+            Assert.True(_detector.IsWindows());
+        }
+
+        [WindowsOnlyFact]
+        public void IsLinux_Should_Return_False_On_Windows()
+        {
+            Assert.False(_detector.IsLinux());
+        }
+    }
+}

--- a/src/Ninja.Sharp.OpenDb2.Tests/ServiceRegistrationTests.cs
+++ b/src/Ninja.Sharp.OpenDb2.Tests/ServiceRegistrationTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Ninja.Sharp.OpenDb2.Interfaces;
 using Ninja.Sharp.OpenDb2.Tests.Attribute;
+using OpenDb2.Interfaces;
 using OpenDb2.Interfaces.Linux;
 using OpenDb2.Interfaces.Windows;
 using OpenDb2.Services;
@@ -193,6 +194,82 @@ namespace Ninja.Sharp.OpenDb2.Tests
             var result = _servicesMock.Object.AddLnxDb2Services(TestConnectionString, _configurationMock.Object);
 
             Assert.Same(_servicesMock.Object, result);
+        }
+
+        [Fact]
+        public void AddDb2Services_Should_Register_IDb2Connection_On_Windows()
+        {
+            var environmentDetectorMock = new Mock<IEnvironmentDetector>();
+            environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.Windows);
+
+            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
+
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [Fact]
+        public void AddDb2Services_Should_Register_IDb2Connection_On_Linux()
+        {
+            var environmentDetectorMock = new Mock<IEnvironmentDetector>();
+            environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.Linux);
+
+            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
+
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [Fact]
+        public void AddDb2Services_Should_Register_IDb2Connection_On_OSX()
+        {
+            var environmentDetectorMock = new Mock<IEnvironmentDetector>();
+            environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.OSX);
+
+            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
+
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [WindowsOnlyFact]
+        public void AddWinDb2Services_Should_Register_IDb2Connection()
+        {
+            _servicesMock.Object.AddWinDb2Services(TestConnectionString, _configurationMock.Object);
+
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [LinuxOnlyFact]
+        public void AddLnxDb2Services_Should_Register_IDb2Connection()
+        {
+            _servicesMock.Object.AddLnxDb2Services(TestConnectionString, _configurationMock.Object);
+
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [WindowsOnlyFact]
+        public void WinDb2Connection_Should_Implement_IDb2Connection()
+        {
+            // Arrange
+            var environmentDetectorMock = new Mock<IEnvironmentDetector>();
+            environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.Windows);
+
+            // Act
+            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
+
+            // Assert - both IWinDb2Connection and IDb2Connection are registered
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IWinDb2Connection))), Times.Once);
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection))), Times.Once);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
@@ -47,6 +47,24 @@ namespace OpenDb2.Drivers.Linux
         }
 
         /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, object value)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToLinux(type), value);
+        }
+
+        /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, int size, object value)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToLinux(type), size, value);
+        }
+
+        /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, int size, ParameterDirection direction)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToLinux(type), size, direction);
+        }
+
+        /// <inheritdoc />
         public object ReadParam(string parameterName)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
@@ -22,21 +22,21 @@ namespace OpenDb2.Drivers.Linux
         public void AddParam(string parameterName, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, value);
+            _command.Parameters.Add(parameterName, value ?? DBNull.Value);
         }
 
         /// <inheritdoc />
         public void AddParam(string parameterName, LnxDb2Type type, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, (DB2Type)type).Value = value;
+            _command.Parameters.Add(parameterName, (DB2Type)type).Value = value ?? DBNull.Value;
         }
 
         /// <inheritdoc />
         public void AddParam(string parameterName, LnxDb2Type type, int size, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, (DB2Type)type, size).Value = value;
+            _command.Parameters.Add(parameterName, (DB2Type)type, size).Value = value ?? DBNull.Value;
         }
 
         /// <inheritdoc />
@@ -68,21 +68,26 @@ namespace OpenDb2.Drivers.Linux
         public object ReadParam(string parameterName)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
+            ArgumentException.ThrowIfNullOrWhiteSpace(parameterName);
+
+            if (!_command.Parameters.Contains(parameterName))
+                throw new ArgumentException($"Parameter '{parameterName}' not found.", nameof(parameterName));
+
             return _command.Parameters[parameterName].Value;
         }
 
         /// <inheritdoc />
-        public Task<int> ExecuteNonQuery()
+        public Task<int> ExecuteNonQuery(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            return _command.ExecuteNonQueryAsync();
+            return _command.ExecuteNonQueryAsync(cancellationToken);
         }
 
         /// <inheritdoc />
-        public Task<DbDataReader> ExecuteReader()
+        public Task<DbDataReader> ExecuteReader(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            return _command.ExecuteReaderAsync();
+            return _command.ExecuteReaderAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -98,6 +103,7 @@ namespace OpenDb2.Drivers.Linux
             if (_disposed) return;
             _disposed = true;
             _command.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
@@ -22,7 +22,8 @@ namespace OpenDb2.Drivers.Linux
         public void AddParam(string parameterName, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, value ?? DBNull.Value);
+            var param = new DB2Parameter(parameterName, value ?? DBNull.Value);
+            _command.Parameters.Add(param);
         }
 
         /// <inheritdoc />

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
@@ -66,6 +66,15 @@ namespace OpenDb2.Drivers.Linux
         }
 
         /// <inheritdoc />
+        IDb2Transaction IDb2Connection.BeginTransaction() => BeginTransaction();
+
+        /// <inheritdoc />
+        IDb2Command IDb2Connection.CreateCommand(string commandText, CommandType commandType) => CreateCommand(commandText, commandType);
+
+        /// <inheritdoc />
+        IDb2Command IDb2Connection.CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction) => CreateCommand(commandText, commandType, transaction);
+
+        /// <inheritdoc />
         public void Dispose()
         {
             if (_disposed) return;

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
@@ -70,6 +70,8 @@ namespace OpenDb2.Drivers.Linux
         {
             if (_disposed) return;
             _disposed = true;
+            if (_connection.State != ConnectionState.Closed)
+                _connection.Close();
             _connection.Dispose();
             GC.SuppressFinalize(this);
         }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
@@ -19,10 +19,10 @@ namespace OpenDb2.Drivers.Linux
         private bool _disposed;
 
         /// <inheritdoc />
-        public async Task Open()
+        public async Task Open(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            await _connection.OpenAsync();
+            await _connection.OpenAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -71,6 +71,7 @@ namespace OpenDb2.Drivers.Linux
             if (_disposed) return;
             _disposed = true;
             _connection.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Transaction.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Transaction.cs
@@ -39,6 +39,7 @@ namespace OpenDb2.Drivers.Linux
             if (_disposed) return;
             _disposed = true;
             _transaction.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Command.cs
@@ -22,21 +22,21 @@ namespace OpenDb2.Drivers.Windows
         public void AddParam(string parameterName, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.AddWithValue(parameterName, value);
+            _command.Parameters.AddWithValue(parameterName, value ?? DBNull.Value);
         }
 
         /// <inheritdoc />
         public void AddParam(string parameterName, WinDb2Type type, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, (OleDbType)type).Value = value;
+            _command.Parameters.Add(parameterName, (OleDbType)type).Value = value ?? DBNull.Value;
         }
 
         /// <inheritdoc />
         public void AddParam(string parameterName, WinDb2Type type, int size, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, (OleDbType)type, size).Value = value;
+            _command.Parameters.Add(parameterName, (OleDbType)type, size).Value = value ?? DBNull.Value;
         }
 
         /// <inheritdoc />
@@ -68,21 +68,26 @@ namespace OpenDb2.Drivers.Windows
         public object ReadParam(string parameterName)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
+            ArgumentException.ThrowIfNullOrWhiteSpace(parameterName);
+
+            if (!_command.Parameters.Contains(parameterName))
+                throw new ArgumentException($"Parameter '{parameterName}' not found.", nameof(parameterName));
+
             return _command.Parameters[parameterName].Value;
         }
 
         /// <inheritdoc />
-        public Task<int> ExecuteNonQuery()
+        public Task<int> ExecuteNonQuery(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            return _command.ExecuteNonQueryAsync();
+            return _command.ExecuteNonQueryAsync(cancellationToken);
         }
 
         /// <inheritdoc />
-        public Task<DbDataReader> ExecuteReader()
+        public Task<DbDataReader> ExecuteReader(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            return _command.ExecuteReaderAsync();
+            return _command.ExecuteReaderAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -98,6 +103,7 @@ namespace OpenDb2.Drivers.Windows
             if (_disposed) return;
             _disposed = true;
             _command.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Command.cs
@@ -47,6 +47,24 @@ namespace OpenDb2.Drivers.Windows
         }
 
         /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, object value)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToWindows(type), value);
+        }
+
+        /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, int size, object value)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToWindows(type), size, value);
+        }
+
+        /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, int size, ParameterDirection direction)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToWindows(type), size, direction);
+        }
+
+        /// <inheritdoc />
         public object ReadParam(string parameterName)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
@@ -66,6 +66,15 @@ namespace OpenDb2.Drivers.Windows
         }
 
         /// <inheritdoc />
+        IDb2Transaction IDb2Connection.BeginTransaction() => BeginTransaction();
+
+        /// <inheritdoc />
+        IDb2Command IDb2Connection.CreateCommand(string commandText, CommandType commandType) => CreateCommand(commandText, commandType);
+
+        /// <inheritdoc />
+        IDb2Command IDb2Connection.CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction) => CreateCommand(commandText, commandType, transaction);
+
+        /// <inheritdoc />
         public void Dispose()
         {
             if (_disposed) return;

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
@@ -19,10 +19,10 @@ namespace OpenDb2.Drivers.Windows
         private bool _disposed;
 
         /// <inheritdoc />
-        public async Task Open()
+        public async Task Open(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            await _connection.OpenAsync();
+            await _connection.OpenAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -71,6 +71,7 @@ namespace OpenDb2.Drivers.Windows
             if (_disposed) return;
             _disposed = true;
             _connection.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
@@ -70,6 +70,8 @@ namespace OpenDb2.Drivers.Windows
         {
             if (_disposed) return;
             _disposed = true;
+            if (_connection.State != ConnectionState.Closed)
+                _connection.Close();
             _connection.Dispose();
             GC.SuppressFinalize(this);
         }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Transaction.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Transaction.cs
@@ -39,6 +39,7 @@ namespace OpenDb2.Drivers.Windows
             if (_disposed) return;
             _disposed = true;
             _transaction.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Enums/Db2Type.cs
+++ b/src/Ninja.Sharp.OpenDb2/Enums/Db2Type.cs
@@ -1,0 +1,33 @@
+// (c) 2024 thesharpninjas
+// This code is licensed under MIT license (see LICENSE.txt for details)
+
+namespace OpenDb2.Enums
+{
+    /// <summary>
+    /// Platform-agnostic DB2 data types. These are automatically mapped at runtime
+    /// to the appropriate platform-specific type (<see cref="WinDb2Type"/> or <see cref="LnxDb2Type"/>).
+    /// </summary>
+    public enum Db2Type
+    {
+        SmallInt,
+        Integer,
+        BigInt,
+        Real,
+        Double,
+        Decimal,
+        Numeric,
+        Char,
+        VarChar,
+        LongVarChar,
+        Binary,
+        VarBinary,
+        LongVarBinary,
+        Date,
+        Time,
+        Timestamp,
+        Clob,
+        Blob,
+        Xml,
+        Boolean
+    }
+}

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Command.cs
@@ -56,14 +56,16 @@ namespace OpenDb2.Interfaces
         /// <summary>
         /// Executes the command against the database and returns the number of rows affected.
         /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A task representing the asynchronous operation, with a result of the number of rows affected.</returns>
-        Task<int> ExecuteNonQuery();
+        Task<int> ExecuteNonQuery(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes the command against the database and returns a data reader for reading the results.
         /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A task representing the asynchronous operation, with a result of a <see cref="DbDataReader"/> object for reading the results.</returns>
-        Task<DbDataReader> ExecuteReader();
+        Task<DbDataReader> ExecuteReader(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a data adapter for use with the command.

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Command.cs
@@ -1,6 +1,8 @@
 ﻿// (c) 2024 thesharpninjas
 // This code is licensed under MIT license (see LICENSE.txt for details)
 
+using OpenDb2.Enums;
+using System.Data;
 using System.Data.Common;
 
 namespace OpenDb2.Interfaces
@@ -16,6 +18,33 @@ namespace OpenDb2.Interfaces
         /// <param name="parameterName">The name of the parameter to add.</param>
         /// <param name="value">The value of the parameter to add.</param>
         void AddParam(string parameterName, object value);
+
+        /// <summary>
+        /// Adds a parameter using a platform-agnostic <see cref="Db2Type"/> that is automatically
+        /// mapped to the correct platform-specific type at runtime.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter to add.</param>
+        /// <param name="type">The platform-agnostic data type.</param>
+        /// <param name="value">The value of the parameter.</param>
+        void AddParam(string parameterName, Db2Type type, object value);
+
+        /// <summary>
+        /// Adds a parameter using a platform-agnostic <see cref="Db2Type"/> with a specified size.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter to add.</param>
+        /// <param name="type">The platform-agnostic data type.</param>
+        /// <param name="size">The size of the parameter.</param>
+        /// <param name="value">The value of the parameter.</param>
+        void AddParam(string parameterName, Db2Type type, int size, object value);
+
+        /// <summary>
+        /// Adds a parameter using a platform-agnostic <see cref="Db2Type"/> with a specified size and direction.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter to add.</param>
+        /// <param name="type">The platform-agnostic data type.</param>
+        /// <param name="size">The size of the parameter.</param>
+        /// <param name="direction">The direction of the parameter.</param>
+        void AddParam(string parameterName, Db2Type type, int size, ParameterDirection direction);
 
         /// <summary>
         /// Retrieves the value of a parameter with the specified name.

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Connection.cs
@@ -11,8 +11,9 @@ namespace OpenDb2.Interfaces
         /// <summary>
         /// Asynchronously opens the DB2 database connection.
         /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        Task Open();
+        Task Open(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously closes the DB2 database connection.

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Connection.cs
@@ -1,6 +1,8 @@
 ﻿// (c) 2024 thesharpninjas
 // This code is licensed under MIT license (see LICENSE.txt for details)
 
+using System.Data;
+
 namespace OpenDb2.Interfaces
 {
     /// <summary>
@@ -20,5 +22,28 @@ namespace OpenDb2.Interfaces
         /// </summary>
         /// <returns>A task representing the asynchronous operation.</returns>
         Task Close();
+
+        /// <summary>
+        /// Begins a new transaction on the DB2 connection.
+        /// </summary>
+        /// <returns>An instance of <see cref="IDb2Transaction"/> representing the new transaction.</returns>
+        IDb2Transaction BeginTransaction();
+
+        /// <summary>
+        /// Creates a new command to be executed against the DB2 database.
+        /// </summary>
+        /// <param name="commandText">The query or stored procedure to execute.</param>
+        /// <param name="commandType">The type of command (e.g., Text, StoredProcedure).</param>
+        /// <returns>An instance of <see cref="IDb2Command"/> representing the new command.</returns>
+        IDb2Command CreateCommand(string commandText, CommandType commandType);
+
+        /// <summary>
+        /// Creates a new command to be executed against the DB2 database within the context of a transaction.
+        /// </summary>
+        /// <param name="commandText">The query or stored procedure to execute.</param>
+        /// <param name="commandType">The type of command (e.g., Text, StoredProcedure).</param>
+        /// <param name="transaction">The transaction within which the command should execute.</param>
+        /// <returns>An instance of <see cref="IDb2Command"/> representing the new command.</returns>
+        IDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction);
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/Linux/ILnxDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/Linux/ILnxDb2Connection.cs
@@ -14,7 +14,7 @@ namespace OpenDb2.Interfaces.Linux
         /// Begins a new transaction on the DB2 connection.
         /// </summary>
         /// <returns>A new instance of <see cref="ILnxDb2Transaction"/> representing the transaction.</returns>
-        ILnxDb2Transaction BeginTransaction();
+        new ILnxDb2Transaction BeginTransaction();
 
         /// <summary>
         /// Creates a new command with the specified command text and type.
@@ -22,7 +22,7 @@ namespace OpenDb2.Interfaces.Linux
         /// <param name="commandText">The query or stored procedure name to execute.</param>
         /// <param name="commandType">The type of command (e.g., Text, StoredProcedure, TableDirect).</param>
         /// <returns>A new instance of <see cref="ILnxDb2Command"/> configured with the specified command text and type.</returns>
-        ILnxDb2Command CreateCommand(string commandText, CommandType commandType);
+        new ILnxDb2Command CreateCommand(string commandText, CommandType commandType);
 
         /// <summary>
         /// Creates a new command with the specified command text, type, and transaction.
@@ -31,6 +31,6 @@ namespace OpenDb2.Interfaces.Linux
         /// <param name="commandType">The type of command (e.g., Text, StoredProcedure, TableDirect).</param>
         /// <param name="transaction">The transaction within which the command executes.</param>
         /// <returns>A new instance of <see cref="ILnxDb2Command"/> configured with the specified parameters.</returns>
-        ILnxDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction);
+        new ILnxDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction);
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/Windows/IWinDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/Windows/IWinDb2Connection.cs
@@ -14,7 +14,7 @@ namespace OpenDb2.Interfaces.Windows
         /// Begins a new transaction on the DB2 connection.
         /// </summary>
         /// <returns>An instance of <see cref="IWinDb2Transaction"/> representing the new transaction.</returns>
-        IWinDb2Transaction BeginTransaction();
+        new IWinDb2Transaction BeginTransaction();
 
         /// <summary>
         /// Creates a new command to be executed against the DB2 database.
@@ -22,7 +22,7 @@ namespace OpenDb2.Interfaces.Windows
         /// <param name="commandText">The query or stored procedure to execute.</param>
         /// <param name="commandType">The type of command (e.g., Text, StoredProcedure).</param>
         /// <returns>An instance of <see cref="IWinDb2Command"/> representing the new command.</returns>
-        IWinDb2Command CreateCommand(string commandText, CommandType commandType);
+        new IWinDb2Command CreateCommand(string commandText, CommandType commandType);
 
         /// <summary>
         /// Creates a new command to be executed against the DB2 database within the context of a transaction.
@@ -31,6 +31,6 @@ namespace OpenDb2.Interfaces.Windows
         /// <param name="commandType">The type of command (e.g., Text, StoredProcedure).</param>
         /// <param name="transaction">The transaction within which the command should execute.</param>
         /// <returns>An instance of <see cref="IWinDb2Command"/> representing the new command.</returns>
-        IWinDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction);
+        new IWinDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction);
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Ninja.Sharp.OpenDb2.csproj
+++ b/src/Ninja.Sharp.OpenDb2/Ninja.Sharp.OpenDb2.csproj
@@ -37,17 +37,24 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="System.Data.OleDb" Version="10.0.7" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Net.IBM.Data.Db2-lnx" Version="10.0.0.100" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
+    <PackageReference Include="System.Data.OleDb" Version="9.0.7" />
+    <PackageReference Include="Net.IBM.Data.Db2-lnx" Version="9.0.0.400" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="System.Data.OleDb" Version="8.0.1" />
     <PackageReference Include="Net.IBM.Data.Db2-lnx" Version="9.0.0.400" />
   </ItemGroup>
 

--- a/src/Ninja.Sharp.OpenDb2/Services/ServiceRegistration.cs
+++ b/src/Ninja.Sharp.OpenDb2/Services/ServiceRegistration.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Ninja.Sharp.OpenDb2.Interfaces;
 using Ninja.Sharp.OpenDb2.Utilities;
+using OpenDb2.Interfaces;
 using OpenDb2.Drivers.Linux;
 using OpenDb2.Drivers.Windows;
 using OpenDb2.Interfaces.Linux;
@@ -63,12 +64,15 @@ namespace OpenDb2.Services
             {
                 case var os when os == OSPlatform.Windows:
                     services.AddScoped<IWinDb2Connection>(sp => new WinDb2Connection(connectionString));
+                    services.AddScoped<IDb2Connection>(sp => sp.GetRequiredService<IWinDb2Connection>());
                     break;
                 case var os when os == OSPlatform.Linux:
                     services.AddScoped<ILnxDb2Connection>(sp => new LnxDb2Connection(connectionString));
+                    services.AddScoped<IDb2Connection>(sp => sp.GetRequiredService<ILnxDb2Connection>());
                     break;
                 case var os when os == OSPlatform.OSX:
                     services.AddScoped<ILnxDb2Connection>(sp => new LnxDb2Connection(connectionString));
+                    services.AddScoped<IDb2Connection>(sp => sp.GetRequiredService<ILnxDb2Connection>());
                     break;
                 default:
                     throw new NotSupportedException("Unsupported operating system platform.");
@@ -93,6 +97,7 @@ namespace OpenDb2.Services
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
             services.AddScoped<IWinDb2Connection>(sp => new WinDb2Connection(connectionString));
+            services.AddScoped<IDb2Connection>(sp => sp.GetRequiredService<IWinDb2Connection>());
 
             return services;
         }
@@ -113,6 +118,7 @@ namespace OpenDb2.Services
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
             services.AddScoped<ILnxDb2Connection>(sp => new LnxDb2Connection(connectionString));
+            services.AddScoped<IDb2Connection>(sp => sp.GetRequiredService<ILnxDb2Connection>());
 
             return services;
         }

--- a/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
+++ b/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
@@ -1,0 +1,85 @@
+// (c) 2024 thesharpninjas
+// This code is licensed under MIT license (see LICENSE.txt for details)
+
+using Ninja.Sharp.OpenDb2.Interfaces;
+using System.Collections.Frozen;
+
+namespace OpenDb2.Enums
+{
+    /// <summary>
+    /// Maps platform-agnostic <see cref="Db2Type"/> values to the corresponding
+    /// <see cref="WinDb2Type"/> or <see cref="LnxDb2Type"/> at runtime based on the current OS.
+    /// </summary>
+    public static class Db2TypeMapper
+    {
+        private static readonly FrozenDictionary<Db2Type, WinDb2Type> s_toWin = new Dictionary<Db2Type, WinDb2Type>
+        {
+            [Db2Type.SmallInt] = WinDb2Type.SmallInt,
+            [Db2Type.Integer] = WinDb2Type.Integer,
+            [Db2Type.BigInt] = WinDb2Type.BigInt,
+            [Db2Type.Real] = WinDb2Type.Single,
+            [Db2Type.Double] = WinDb2Type.Double,
+            [Db2Type.Decimal] = WinDb2Type.Decimal,
+            [Db2Type.Numeric] = WinDb2Type.Numeric,
+            [Db2Type.Char] = WinDb2Type.Char,
+            [Db2Type.VarChar] = WinDb2Type.VarChar,
+            [Db2Type.LongVarChar] = WinDb2Type.LongVarChar,
+            [Db2Type.Binary] = WinDb2Type.Binary,
+            [Db2Type.VarBinary] = WinDb2Type.VarBinary,
+            [Db2Type.LongVarBinary] = WinDb2Type.LongVarBinary,
+            [Db2Type.Date] = WinDb2Type.DBDate,
+            [Db2Type.Time] = WinDb2Type.DBTime,
+            [Db2Type.Timestamp] = WinDb2Type.DBTimeStamp,
+            [Db2Type.Clob] = WinDb2Type.LongVarWChar,
+            [Db2Type.Blob] = WinDb2Type.LongVarBinary,
+            [Db2Type.Xml] = WinDb2Type.LongVarWChar,
+            [Db2Type.Boolean] = WinDb2Type.Boolean,
+        }.ToFrozenDictionary();
+
+        private static readonly FrozenDictionary<Db2Type, LnxDb2Type> s_toLnx = new Dictionary<Db2Type, LnxDb2Type>
+        {
+            [Db2Type.SmallInt] = LnxDb2Type.SmallInt,
+            [Db2Type.Integer] = LnxDb2Type.Integer,
+            [Db2Type.BigInt] = LnxDb2Type.BigInt,
+            [Db2Type.Real] = LnxDb2Type.Real,
+            [Db2Type.Double] = LnxDb2Type.Double,
+            [Db2Type.Decimal] = LnxDb2Type.Decimal,
+            [Db2Type.Numeric] = LnxDb2Type.Numeric,
+            [Db2Type.Char] = LnxDb2Type.Char,
+            [Db2Type.VarChar] = LnxDb2Type.VarChar,
+            [Db2Type.LongVarChar] = LnxDb2Type.LongVarChar,
+            [Db2Type.Binary] = LnxDb2Type.Binary,
+            [Db2Type.VarBinary] = LnxDb2Type.VarBinary,
+            [Db2Type.LongVarBinary] = LnxDb2Type.LongVarBinary,
+            [Db2Type.Date] = LnxDb2Type.Date,
+            [Db2Type.Time] = LnxDb2Type.Time,
+            [Db2Type.Timestamp] = LnxDb2Type.Timestamp,
+            [Db2Type.Clob] = LnxDb2Type.Clob,
+            [Db2Type.Blob] = LnxDb2Type.Blob,
+            [Db2Type.Xml] = LnxDb2Type.Xml,
+            [Db2Type.Boolean] = LnxDb2Type.Boolean,
+        }.ToFrozenDictionary();
+
+        /// <summary>
+        /// Converts a <see cref="Db2Type"/> to the corresponding <see cref="WinDb2Type"/>.
+        /// </summary>
+        /// <exception cref="NotSupportedException">Thrown when the type has no Windows mapping.</exception>
+        public static WinDb2Type ToWindows(Db2Type type)
+        {
+            return s_toWin.TryGetValue(type, out var result)
+                ? result
+                : throw new NotSupportedException($"Db2Type '{type}' has no Windows (OleDb) mapping.");
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Db2Type"/> to the corresponding <see cref="LnxDb2Type"/>.
+        /// </summary>
+        /// <exception cref="NotSupportedException">Thrown when the type has no Linux mapping.</exception>
+        public static LnxDb2Type ToLinux(Db2Type type)
+        {
+            return s_toLnx.TryGetValue(type, out var result)
+                ? result
+                : throw new NotSupportedException($"Db2Type '{type}' has no Linux (IBM.Data.Db2) mapping.");
+        }
+    }
+}

--- a/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
+++ b/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
@@ -1,7 +1,6 @@
 // (c) 2024 thesharpninjas
 // This code is licensed under MIT license (see LICENSE.txt for details)
 
-using Ninja.Sharp.OpenDb2.Interfaces;
 using System.Collections.Frozen;
 
 namespace OpenDb2.Enums
@@ -12,6 +11,18 @@ namespace OpenDb2.Enums
     /// </summary>
     public static class Db2TypeMapper
     {
+        static Db2TypeMapper()
+        {
+            var allValues = Enum.GetValues<Db2Type>();
+            foreach (var value in allValues)
+            {
+                if (!s_toWin.ContainsKey(value))
+                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Windows (OleDb) mapping in {nameof(Db2TypeMapper)}.");
+                if (!s_toLnx.ContainsKey(value))
+                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Linux (IBM.Data.Db2) mapping in {nameof(Db2TypeMapper)}.");
+            }
+        }
+
         private static readonly FrozenDictionary<Db2Type, WinDb2Type> s_toWin = new Dictionary<Db2Type, WinDb2Type>
         {
             [Db2Type.SmallInt] = WinDb2Type.SmallInt,
@@ -30,9 +41,9 @@ namespace OpenDb2.Enums
             [Db2Type.Date] = WinDb2Type.DBDate,
             [Db2Type.Time] = WinDb2Type.DBTime,
             [Db2Type.Timestamp] = WinDb2Type.DBTimeStamp,
-            [Db2Type.Clob] = WinDb2Type.LongVarWChar,
-            [Db2Type.Blob] = WinDb2Type.LongVarBinary,
-            [Db2Type.Xml] = WinDb2Type.LongVarWChar,
+            [Db2Type.Clob] = WinDb2Type.LongVarWChar,  // OleDb has no native CLOB; mapped to LongVarWChar (same as Xml)
+            [Db2Type.Blob] = WinDb2Type.LongVarBinary,  // OleDb has no native BLOB; mapped to LongVarBinary (same as LongVarBinary)
+            [Db2Type.Xml] = WinDb2Type.LongVarWChar,    // OleDb has no native XML; mapped to LongVarWChar (same as Clob)
             [Db2Type.Boolean] = WinDb2Type.Boolean,
         }.ToFrozenDictionary();
 

--- a/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
+++ b/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
@@ -11,18 +11,6 @@ namespace OpenDb2.Enums
     /// </summary>
     public static class Db2TypeMapper
     {
-        static Db2TypeMapper()
-        {
-            var allValues = Enum.GetValues<Db2Type>();
-            foreach (var value in allValues)
-            {
-                if (!s_toWin.ContainsKey(value))
-                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Windows (OleDb) mapping in {nameof(Db2TypeMapper)}.");
-                if (!s_toLnx.ContainsKey(value))
-                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Linux (IBM.Data.Db2) mapping in {nameof(Db2TypeMapper)}.");
-            }
-        }
-
         private static readonly FrozenDictionary<Db2Type, WinDb2Type> s_toWin = new Dictionary<Db2Type, WinDb2Type>
         {
             [Db2Type.SmallInt] = WinDb2Type.SmallInt,
@@ -70,6 +58,18 @@ namespace OpenDb2.Enums
             [Db2Type.Xml] = LnxDb2Type.Xml,
             [Db2Type.Boolean] = LnxDb2Type.Boolean,
         }.ToFrozenDictionary();
+
+        static Db2TypeMapper()
+        {
+            var allValues = Enum.GetValues<Db2Type>();
+            foreach (var value in allValues)
+            {
+                if (!s_toWin.ContainsKey(value))
+                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Windows (OleDb) mapping in {nameof(Db2TypeMapper)}.");
+                if (!s_toLnx.ContainsKey(value))
+                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Linux (IBM.Data.Db2) mapping in {nameof(Db2TypeMapper)}.");
+            }
+        }
 
         /// <summary>
         /// Converts a <see cref="Db2Type"/> to the corresponding <see cref="WinDb2Type"/>.


### PR DESCRIPTION
Added CreateCommand(string, CommandType) and BeginTransaction() methods to the base IDb2Connection interface, enabling consumers to work in a platform-agnostic way without depending on IWinDb2Connection or ILnxDb2Connection. Registered IDb2Connection in the DI container alongside platform-specific interfaces. Added unit tests for Db2TypeMapper, EnvironmentDetector, WinDb2Connection, and WinDb2Command bringing coverage from ~9% to ~52%.