### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,74 @@
 
 # Ninja.Sharp.OpenDb2
 
-This .NET library provides an abstraction layer over DB2 database access methods, facilitating dependency injection and enabling easier mocking and testing of database interactions.
+A lightweight .NET library that provides a clean abstraction layer over IBM DB2 database connectivity.
+It wraps the underlying ADO.NET drivers behind testable interfaces, making it straightforward to use dependency injection, write unit tests with mocked connections, and deploy the same codebase across Windows, Linux, and macOS.
 
-## Generic Service registration
+The library targets .NET 8, .NET 9, and .NET 10.
 
-You can register the OpenDB2 service simply with dependency injection:
+## Installation
+
+Install the package from NuGet:
+
+```
+dotnet add package Ninja.Sharp.OpenDb2
+```
+
+Or via the Package Manager Console in Visual Studio:
+
+```
+Install-Package Ninja.Sharp.OpenDb2
+```
+
+## How It Works
+
+On Windows the library uses `System.Data.OleDb` to communicate with DB2.
+On Linux and macOS it relies on the official IBM.Data.Db2 driver instead.
+
+Both paths expose the same programming model through platform-specific interfaces (`IWinDb2Connection` / `ILnxDb2Connection`) that share a common base (`IDb2Connection`).
+The connection is registered as a **scoped** service, so each DI scope (typically one per HTTP request) gets its own connection instance.
+
+## Service Registration
+
+### Automatic platform detection
+
+The `AddDb2Services` method inspects the runtime OS at startup and registers the correct connection type automatically.
+This is the recommended approach for applications that need to run on more than one platform:
 
 ``` csharp
-builder.services
+builder.Services
    .AddDb2Services(connectionString, configuration);
 ```
 
-## Usage - On Windows
+On Windows this registers `IWinDb2Connection`; on Linux and macOS it registers `ILnxDb2Connection`.
+If the platform is not recognized, a `NotSupportedException` is thrown at startup so you get an immediate, clear failure.
 
-Windows Service registration:
+### Explicit platform registration
+
+When the target platform is known at build time you can register the connection directly.
+
+On Windows:
 
 ``` csharp
-builder.services
+builder.Services
    .AddWinDb2Services(connectionString, configuration);
 ```
 
-Calling stored procedure:
+On Linux or macOS:
+
+``` csharp
+builder.Services
+   .AddLnxDb2Services(connectionString, configuration);
+```
+
+All registration methods validate their arguments. Passing a `null` service collection throws `ArgumentNullException`; passing a `null`, empty, or whitespace connection string throws `ArgumentException`.
+
+## Usage on Windows
+
+Inject `IWinDb2Connection` into your repository or service class through constructor injection.
+The connection must be opened explicitly before use and should be disposed when it is no longer needed.
+
+### Stored procedure with parameters
 
 ``` csharp
 public class Db2Repository(IWinDb2Connection connection)
@@ -37,37 +84,52 @@ public class Db2Repository(IWinDb2Connection connection)
         {
             await connection.Open();
 
-            // Creating command
-
             using var cmd = connection.CreateCommand("STORED_PROCEDURE_NAME", CommandType.StoredProcedure);
-
-            // Creating parameters
 
             cmd.AddParam("@PARAM1", WinDb2Type.VarChar, 10, param1);
             cmd.AddParam("@PARAM2", WinDb2Type.Decimal, 6, param2);
             cmd.AddParam("@OUTPARAM", WinDb2Type.VarChar, 250, ParameterDirection.Output);
 
-            // Reading output parameter
-
             await cmd.ExecuteNonQuery();
 
             string? outputResult = cmd.ReadParam("@OUTPARAM") as string;
-
-            // Data retrieval from Reader
-
-            using var reader = await cmd.ExecuteReader();
-
-            while (await reader.ReadAsync())
-            {
-                var field1 = reader.GetValue("FIELD1").ToString();
-                var field2 = reader.GetValue("FIELD2").ToString();
-            }
         }
     }
 }
 ```
 
-Executing query with transaction and DataAdapter
+### Reading rows with ExecuteReader
+
+``` csharp
+public class Db2Repository(IWinDb2Connection connection)
+{
+    public async Task<List<string>> GetValues()
+    {
+        using (connection)
+        {
+            await connection.Open();
+
+            using var cmd = connection.CreateCommand("SELECT FIELD1 FROM MY_TABLE", CommandType.Text);
+
+            using var reader = await cmd.ExecuteReader();
+
+            var results = new List<string>();
+
+            while (await reader.ReadAsync())
+            {
+                results.Add(reader.GetValue("FIELD1").ToString()!);
+            }
+
+            return results;
+        }
+    }
+}
+```
+
+### Query with transaction and DataAdapter
+
+Transactions are started through `BeginTransaction` and must be explicitly committed or rolled back.
+The transaction object is passed to `CreateCommand` so that the command participates in the same unit of work.
 
 ``` csharp
 public class Db2Repository(IWinDb2Connection connection)
@@ -82,15 +144,9 @@ public class Db2Repository(IWinDb2Connection connection)
 
             try
             {
-                // Creating command
-
                 using var cmd = connection.CreateCommand("QUERY", CommandType.Text, transaction);
 
-                // Creating data adapter
-
                 using var adapter = cmd.CreateDataAdapter();
-
-                // Filling and reading DataTable
 
                 DataTable dt = new();
 
@@ -111,16 +167,11 @@ public class Db2Repository(IWinDb2Connection connection)
 }
 ```
 
-## Usage - On Linux
+## Usage on Linux
 
-Linux Service registration:
+The Linux API mirrors the Windows one. Inject `ILnxDb2Connection` instead and use `LnxDb2Type` for parameter types.
 
-``` csharp
-builder.services
-   .AddLnxDb2Services(connectionString, configuration);
-```
-
-Calling stored procedure:
+### Stored procedure with parameters
 
 ``` csharp
 public class Db2Repository(ILnxDb2Connection connection)
@@ -131,37 +182,49 @@ public class Db2Repository(ILnxDb2Connection connection)
         {
             await connection.Open();
 
-            // Creating command
-
             using var cmd = connection.CreateCommand("STORED_PROCEDURE_NAME", CommandType.StoredProcedure);
-
-            // Creating parameters
 
             cmd.AddParam("@PARAM1", LnxDb2Type.NVarChar, 10, param1);
             cmd.AddParam("@PARAM2", LnxDb2Type.Decimal, 6, param2);
             cmd.AddParam("@OUTPARAM", LnxDb2Type.VarChar, 250, ParameterDirection.Output);
 
-            // Reading output parameter
-
             await cmd.ExecuteNonQuery();
 
             string? outputResult = cmd.ReadParam("@OUTPARAM") as string;
-
-            // Data retrieval from Reader
-
-            using var reader = await cmd.ExecuteReader();
-
-            while (await reader.ReadAsync())
-            {
-                var field1 = reader.GetValue("FIELD1").ToString();
-                var field2 = reader.GetValue("FIELD2").ToString();
-            }
         }
     }
 }
 ```
 
-Executing query with transaction and DataAdapter
+### Reading rows with ExecuteReader
+
+``` csharp
+public class Db2Repository(ILnxDb2Connection connection)
+{
+    public async Task<List<string>> GetValues()
+    {
+        using (connection)
+        {
+            await connection.Open();
+
+            using var cmd = connection.CreateCommand("SELECT FIELD1 FROM MY_TABLE", CommandType.Text);
+
+            using var reader = await cmd.ExecuteReader();
+
+            var results = new List<string>();
+
+            while (await reader.ReadAsync())
+            {
+                results.Add(reader.GetValue("FIELD1").ToString()!);
+            }
+
+            return results;
+        }
+    }
+}
+```
+
+### Query with transaction and DataAdapter
 
 ``` csharp
 public class Db2Repository(ILnxDb2Connection connection)
@@ -176,15 +239,9 @@ public class Db2Repository(ILnxDb2Connection connection)
 
             try
             {
-                // Creating command
-
                 using var cmd = connection.CreateCommand("QUERY", CommandType.Text, transaction);
 
-                // Creating data adapter
-
                 using var adapter = cmd.CreateDataAdapter();
-
-                // Filling and reading DataTable
 
                 DataTable dt = new();
 
@@ -205,10 +262,32 @@ public class Db2Repository(ILnxDb2Connection connection)
 }
 ```
 
-## Licensee
-Repository source code is available under MIT License, see license in the source.
+## Supported Platforms
+
+| Operating System | Driver | Interface | Type Enum |
+|---|---|---|---|
+| Windows | System.Data.OleDb | `IWinDb2Connection` | `WinDb2Type` |
+| Linux | IBM.Data.Db2 | `ILnxDb2Connection` | `LnxDb2Type` |
+| macOS | IBM.Data.Db2 | `ILnxDb2Connection` | `LnxDb2Type` |
+
+## Architecture Overview
+
+The library is organized around three core abstractions, each with a Windows and a Linux implementation:
+
+| Abstraction | Windows | Linux / macOS |
+|---|---|---|
+| `IDb2Connection` | `WinDb2Connection` (OleDb) | `LnxDb2Connection` (IBM.Data.Db2) |
+| `IDb2Command` | `WinDb2Command` | `LnxDb2Command` |
+| `IDb2Transaction` | `WinDb2Transaction` | `LnxDb2Transaction` |
+
+Service registration is handled by the `ServiceRegistration` static class, which exposes the `AddDb2Services`, `AddWinDb2Services`, and `AddLnxDb2Services` extension methods on `IServiceCollection`.
+
+## License
+
+Repository source code is available under the MIT License. See [LICENSE.txt](LICENSE.txt) for details.
 
 ## Contributing
+
 Thank you for considering to help out with the source code!
 If you'd like to contribute, please fork, fix, commit and send a pull request for the maintainers to review and merge into the main code base.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,64 @@ builder.Services
 
 All registration methods validate their arguments. Passing a `null` service collection throws `ArgumentNullException`; passing a `null`, empty, or whitespace connection string throws `ArgumentException`.
 
+## Cross-Platform Data Types
+
+The library provides a platform-agnostic `Db2Type` enum that is automatically mapped at runtime to the correct platform-specific type (`WinDb2Type` on Windows, `LnxDb2Type` on Linux/macOS). This allows you to write code that works on any OS without `#if` directives or platform checks.
+
+### Available types
+
+| Db2Type | Windows (OleDb) | Linux (IBM.Data.Db2) |
+|---|---|---|
+| `SmallInt` | `SmallInt` | `SmallInt` |
+| `Integer` | `Integer` | `Integer` |
+| `BigInt` | `BigInt` | `BigInt` |
+| `Real` | `Single` | `Real` |
+| `Double` | `Double` | `Double` |
+| `Decimal` | `Decimal` | `Decimal` |
+| `Numeric` | `Numeric` | `Numeric` |
+| `Char` | `Char` | `Char` |
+| `VarChar` | `VarChar` | `VarChar` |
+| `LongVarChar` | `LongVarChar` | `LongVarChar` |
+| `Binary` | `Binary` | `Binary` |
+| `VarBinary` | `VarBinary` | `VarBinary` |
+| `LongVarBinary` | `LongVarBinary` | `LongVarBinary` |
+| `Date` | `DBDate` | `Date` |
+| `Time` | `DBTime` | `Time` |
+| `Timestamp` | `DBTimeStamp` | `Timestamp` |
+| `Clob` | `LongVarWChar` | `Clob` |
+| `Blob` | `LongVarBinary` | `Blob` |
+| `Xml` | `LongVarWChar` | `Xml` |
+| `Boolean` | `Boolean` | `Boolean` |
+
+### Example: write-once, run-anywhere
+
+Use `AddDb2Services` for automatic platform detection and `Db2Type` for parameters — the same code deploys to Windows, Linux, and macOS without changes:
+
+``` csharp
+public class Db2Repository(IDb2Connection connection)
+{
+    public async Task DoSomething(string param1, int param2)
+    {
+        using (connection)
+        {
+            await connection.Open();
+
+            using var cmd = connection.CreateCommand("STORED_PROCEDURE_NAME", CommandType.StoredProcedure);
+
+            cmd.AddParam("@PARAM1", Db2Type.VarChar, 10, param1);
+            cmd.AddParam("@PARAM2", Db2Type.Decimal, 6, param2);
+            cmd.AddParam("@OUTPARAM", Db2Type.VarChar, 250, ParameterDirection.Output);
+
+            await cmd.ExecuteNonQuery();
+
+            string? outputResult = cmd.ReadParam("@OUTPARAM") as string;
+        }
+    }
+}
+```
+
+You can still use the platform-specific types (`WinDb2Type`, `LnxDb2Type`) directly when you need access to types that don't have a cross-platform equivalent.
+
 ## Usage on Windows
 
 Inject `IWinDb2Connection` into your repository or service class through constructor injection.
@@ -264,11 +322,11 @@ public class Db2Repository(ILnxDb2Connection connection)
 
 ## Supported Platforms
 
-| Operating System | Driver | Interface | Type Enum |
-|---|---|---|---|
-| Windows | System.Data.OleDb | `IWinDb2Connection` | `WinDb2Type` |
-| Linux | IBM.Data.Db2 | `ILnxDb2Connection` | `LnxDb2Type` |
-| macOS | IBM.Data.Db2 | `ILnxDb2Connection` | `LnxDb2Type` |
+| Operating System | Driver | Interface | Platform Type | Cross-Platform Type |
+|---|---|---|---|---|
+| Windows | System.Data.OleDb | `IWinDb2Connection` | `WinDb2Type` | `Db2Type` |
+| Linux | IBM.Data.Db2 | `ILnxDb2Connection` | `LnxDb2Type` | `Db2Type` |
+| macOS | IBM.Data.Db2 | `ILnxDb2Connection` | `LnxDb2Type` | `Db2Type` |
 
 ## Architecture Overview
 

--- a/src/Ninja.Sharp.OpenDb2.Tests/Db2TypeMapperTests.cs
+++ b/src/Ninja.Sharp.OpenDb2.Tests/Db2TypeMapperTests.cs
@@ -1,0 +1,84 @@
+// (c) 2024 thesharpninjas
+// This code is licensed under MIT license (see LICENSE.txt for details)
+
+using OpenDb2.Enums;
+
+namespace Ninja.Sharp.OpenDb2.Tests
+{
+    public class Db2TypeMapperTests
+    {
+        [Theory]
+        [InlineData(Db2Type.SmallInt, WinDb2Type.SmallInt)]
+        [InlineData(Db2Type.Integer, WinDb2Type.Integer)]
+        [InlineData(Db2Type.BigInt, WinDb2Type.BigInt)]
+        [InlineData(Db2Type.Real, WinDb2Type.Single)]
+        [InlineData(Db2Type.Double, WinDb2Type.Double)]
+        [InlineData(Db2Type.Decimal, WinDb2Type.Decimal)]
+        [InlineData(Db2Type.Numeric, WinDb2Type.Numeric)]
+        [InlineData(Db2Type.Char, WinDb2Type.Char)]
+        [InlineData(Db2Type.VarChar, WinDb2Type.VarChar)]
+        [InlineData(Db2Type.LongVarChar, WinDb2Type.LongVarChar)]
+        [InlineData(Db2Type.Binary, WinDb2Type.Binary)]
+        [InlineData(Db2Type.VarBinary, WinDb2Type.VarBinary)]
+        [InlineData(Db2Type.LongVarBinary, WinDb2Type.LongVarBinary)]
+        [InlineData(Db2Type.Date, WinDb2Type.DBDate)]
+        [InlineData(Db2Type.Time, WinDb2Type.DBTime)]
+        [InlineData(Db2Type.Timestamp, WinDb2Type.DBTimeStamp)]
+        [InlineData(Db2Type.Clob, WinDb2Type.LongVarWChar)]
+        [InlineData(Db2Type.Blob, WinDb2Type.LongVarBinary)]
+        [InlineData(Db2Type.Xml, WinDb2Type.LongVarWChar)]
+        [InlineData(Db2Type.Boolean, WinDb2Type.Boolean)]
+        public void ToWindows_Should_Map_Correctly(Db2Type input, WinDb2Type expected)
+        {
+            var result = Db2TypeMapper.ToWindows(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(Db2Type.SmallInt, LnxDb2Type.SmallInt)]
+        [InlineData(Db2Type.Integer, LnxDb2Type.Integer)]
+        [InlineData(Db2Type.BigInt, LnxDb2Type.BigInt)]
+        [InlineData(Db2Type.Real, LnxDb2Type.Real)]
+        [InlineData(Db2Type.Double, LnxDb2Type.Double)]
+        [InlineData(Db2Type.Decimal, LnxDb2Type.Decimal)]
+        [InlineData(Db2Type.Numeric, LnxDb2Type.Numeric)]
+        [InlineData(Db2Type.Char, LnxDb2Type.Char)]
+        [InlineData(Db2Type.VarChar, LnxDb2Type.VarChar)]
+        [InlineData(Db2Type.LongVarChar, LnxDb2Type.LongVarChar)]
+        [InlineData(Db2Type.Binary, LnxDb2Type.Binary)]
+        [InlineData(Db2Type.VarBinary, LnxDb2Type.VarBinary)]
+        [InlineData(Db2Type.LongVarBinary, LnxDb2Type.LongVarBinary)]
+        [InlineData(Db2Type.Date, LnxDb2Type.Date)]
+        [InlineData(Db2Type.Time, LnxDb2Type.Time)]
+        [InlineData(Db2Type.Timestamp, LnxDb2Type.Timestamp)]
+        [InlineData(Db2Type.Clob, LnxDb2Type.Clob)]
+        [InlineData(Db2Type.Blob, LnxDb2Type.Blob)]
+        [InlineData(Db2Type.Xml, LnxDb2Type.Xml)]
+        [InlineData(Db2Type.Boolean, LnxDb2Type.Boolean)]
+        public void ToLinux_Should_Map_Correctly(Db2Type input, LnxDb2Type expected)
+        {
+            var result = Db2TypeMapper.ToLinux(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void All_Db2Type_Values_Should_Have_Windows_Mapping()
+        {
+            foreach (var type in Enum.GetValues<Db2Type>())
+            {
+                var exception = Record.Exception(() => Db2TypeMapper.ToWindows(type));
+                Assert.Null(exception);
+            }
+        }
+
+        [Fact]
+        public void All_Db2Type_Values_Should_Have_Linux_Mapping()
+        {
+            foreach (var type in Enum.GetValues<Db2Type>())
+            {
+                var exception = Record.Exception(() => Db2TypeMapper.ToLinux(type));
+                Assert.Null(exception);
+            }
+        }
+    }
+}

--- a/src/Ninja.Sharp.OpenDb2.Tests/EnvironmentDetectorTests.cs
+++ b/src/Ninja.Sharp.OpenDb2.Tests/EnvironmentDetectorTests.cs
@@ -1,0 +1,33 @@
+// (c) 2024 thesharpninjas
+// This code is licensed under MIT license (see LICENSE.txt for details)
+
+using Ninja.Sharp.OpenDb2.Interfaces;
+using Ninja.Sharp.OpenDb2.Tests.Attribute;
+using Ninja.Sharp.OpenDb2.Utilities;
+using System.Runtime.InteropServices;
+
+namespace Ninja.Sharp.OpenDb2.Tests
+{
+    public class EnvironmentDetectorTests
+    {
+        private readonly IEnvironmentDetector _detector = new EnvironmentDetector();
+
+        [WindowsOnlyFact]
+        public void GetCurrentOSPlatform_Should_Return_Windows_On_Windows()
+        {
+            Assert.Equal(OSPlatform.Windows, _detector.GetCurrentOSPlatform());
+        }
+
+        [WindowsOnlyFact]
+        public void IsWindows_Should_Return_True_On_Windows()
+        {
+            Assert.True(_detector.IsWindows());
+        }
+
+        [WindowsOnlyFact]
+        public void IsLinux_Should_Return_False_On_Windows()
+        {
+            Assert.False(_detector.IsLinux());
+        }
+    }
+}

--- a/src/Ninja.Sharp.OpenDb2.Tests/Ninja.Sharp.OpenDb2.Tests.csproj
+++ b/src/Ninja.Sharp.OpenDb2.Tests/Ninja.Sharp.OpenDb2.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,17 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ninja.Sharp.OpenDb2.Tests/ServiceRegistrationTests.cs
+++ b/src/Ninja.Sharp.OpenDb2.Tests/ServiceRegistrationTests.cs
@@ -25,7 +25,7 @@ namespace Ninja.Sharp.OpenDb2.Tests
             _configurationMock = new Mock<IConfiguration>();
         }
 
-        [WindowsOnlyFact]
+        [Fact]
         public void AddDb2Services_Should_Register_WinDb2Connection_On_Windows()
         {
             // Arrange
@@ -33,7 +33,7 @@ namespace Ninja.Sharp.OpenDb2.Tests
             environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.Windows);
 
             // Act
-            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object);
+            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
 
             // Assert
             _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
@@ -41,7 +41,7 @@ namespace Ninja.Sharp.OpenDb2.Tests
                 sd.ImplementationFactory != null)), Times.Once);
         }
 
-        [LinuxOnlyFact]
+        [Fact]
         public void AddDb2Services_Should_Register_LnxDb2Connection_On_Linux()
         {
             // Arrange
@@ -49,12 +49,150 @@ namespace Ninja.Sharp.OpenDb2.Tests
             environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.Linux);
 
             // Act
-            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object);
+            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
 
             // Assert
             _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
                 sd.ServiceType == typeof(ILnxDb2Connection) &&
                 sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [Fact]
+        public void AddDb2Services_Should_Throw_ArgumentNullException_When_Services_Is_Null()
+        {
+            IServiceCollection? services = null;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                services!.AddDb2Services(TestConnectionString, _configurationMock.Object));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void AddDb2Services_Should_Throw_ArgumentException_When_ConnectionString_Is_Invalid(string? connectionString)
+        {
+            Assert.ThrowsAny<ArgumentException>(() =>
+                _servicesMock.Object.AddDb2Services(connectionString!, _configurationMock.Object));
+        }
+
+        [Fact]
+        public void AddWinDb2Services_Should_Throw_ArgumentNullException_When_Services_Is_Null()
+        {
+            IServiceCollection? services = null;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                services!.AddWinDb2Services(TestConnectionString, _configurationMock.Object));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void AddWinDb2Services_Should_Throw_ArgumentException_When_ConnectionString_Is_Invalid(string? connectionString)
+        {
+            Assert.ThrowsAny<ArgumentException>(() =>
+                _servicesMock.Object.AddWinDb2Services(connectionString!, _configurationMock.Object));
+        }
+
+        [WindowsOnlyFact]
+        public void AddWinDb2Services_Should_Register_WinDb2Connection()
+        {
+            // Act
+            _servicesMock.Object.AddWinDb2Services(TestConnectionString, _configurationMock.Object);
+
+            // Assert
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IWinDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [Fact]
+        public void AddLnxDb2Services_Should_Throw_ArgumentNullException_When_Services_Is_Null()
+        {
+            IServiceCollection? services = null;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                services!.AddLnxDb2Services(TestConnectionString, _configurationMock.Object));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void AddLnxDb2Services_Should_Throw_ArgumentException_When_ConnectionString_Is_Invalid(string? connectionString)
+        {
+            Assert.ThrowsAny<ArgumentException>(() =>
+                _servicesMock.Object.AddLnxDb2Services(connectionString!, _configurationMock.Object));
+        }
+
+        [LinuxOnlyFact]
+        public void AddLnxDb2Services_Should_Register_LnxDb2Connection()
+        {
+            // Act
+            _servicesMock.Object.AddLnxDb2Services(TestConnectionString, _configurationMock.Object);
+
+            // Assert
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(ILnxDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [Fact]
+        public void AddDb2Services_Should_Return_Same_ServiceCollection()
+        {
+            var environmentDetectorMock = new Mock<IEnvironmentDetector>();
+            environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.Windows);
+
+            var result = _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
+
+            Assert.Same(_servicesMock.Object, result);
+        }
+
+        [Fact]
+        public void AddDb2Services_Should_Register_LnxDb2Connection_On_OSX()
+        {
+            var environmentDetectorMock = new Mock<IEnvironmentDetector>();
+            environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.OSX);
+
+            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
+
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(ILnxDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [Fact]
+        public void AddDb2Services_Should_Throw_NotSupportedException_On_Unknown_Platform()
+        {
+            var environmentDetectorMock = new Mock<IEnvironmentDetector>();
+            environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.Create("Other"));
+
+            Assert.Throws<NotSupportedException>(() =>
+                _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object));
+        }
+
+        [Fact]
+        public void AddDb2Services_Should_Throw_ArgumentNullException_When_EnvironmentDetector_Is_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, null!));
+        }
+
+        [WindowsOnlyFact]
+        public void AddWinDb2Services_Should_Return_Same_ServiceCollection()
+        {
+            var result = _servicesMock.Object.AddWinDb2Services(TestConnectionString, _configurationMock.Object);
+
+            Assert.Same(_servicesMock.Object, result);
+        }
+
+        [LinuxOnlyFact]
+        public void AddLnxDb2Services_Should_Return_Same_ServiceCollection()
+        {
+            var result = _servicesMock.Object.AddLnxDb2Services(TestConnectionString, _configurationMock.Object);
+
+            Assert.Same(_servicesMock.Object, result);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2.Tests/ServiceRegistrationTests.cs
+++ b/src/Ninja.Sharp.OpenDb2.Tests/ServiceRegistrationTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Ninja.Sharp.OpenDb2.Interfaces;
 using Ninja.Sharp.OpenDb2.Tests.Attribute;
+using OpenDb2.Interfaces;
 using OpenDb2.Interfaces.Linux;
 using OpenDb2.Interfaces.Windows;
 using OpenDb2.Services;
@@ -193,6 +194,82 @@ namespace Ninja.Sharp.OpenDb2.Tests
             var result = _servicesMock.Object.AddLnxDb2Services(TestConnectionString, _configurationMock.Object);
 
             Assert.Same(_servicesMock.Object, result);
+        }
+
+        [Fact]
+        public void AddDb2Services_Should_Register_IDb2Connection_On_Windows()
+        {
+            var environmentDetectorMock = new Mock<IEnvironmentDetector>();
+            environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.Windows);
+
+            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
+
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [Fact]
+        public void AddDb2Services_Should_Register_IDb2Connection_On_Linux()
+        {
+            var environmentDetectorMock = new Mock<IEnvironmentDetector>();
+            environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.Linux);
+
+            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
+
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [Fact]
+        public void AddDb2Services_Should_Register_IDb2Connection_On_OSX()
+        {
+            var environmentDetectorMock = new Mock<IEnvironmentDetector>();
+            environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.OSX);
+
+            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
+
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [WindowsOnlyFact]
+        public void AddWinDb2Services_Should_Register_IDb2Connection()
+        {
+            _servicesMock.Object.AddWinDb2Services(TestConnectionString, _configurationMock.Object);
+
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [LinuxOnlyFact]
+        public void AddLnxDb2Services_Should_Register_IDb2Connection()
+        {
+            _servicesMock.Object.AddLnxDb2Services(TestConnectionString, _configurationMock.Object);
+
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection) &&
+                sd.ImplementationFactory != null)), Times.Once);
+        }
+
+        [WindowsOnlyFact]
+        public void WinDb2Connection_Should_Implement_IDb2Connection()
+        {
+            // Arrange
+            var environmentDetectorMock = new Mock<IEnvironmentDetector>();
+            environmentDetectorMock.Setup(e => e.GetCurrentOSPlatform()).Returns(OSPlatform.Windows);
+
+            // Act
+            _servicesMock.Object.AddDb2Services(TestConnectionString, _configurationMock.Object, environmentDetectorMock.Object);
+
+            // Assert - both IWinDb2Connection and IDb2Connection are registered
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IWinDb2Connection))), Times.Once);
+            _servicesMock.Verify(s => s.Add(It.Is<ServiceDescriptor>(sd =>
+                sd.ServiceType == typeof(IDb2Connection))), Times.Once);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
@@ -47,6 +47,24 @@ namespace OpenDb2.Drivers.Linux
         }
 
         /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, object value)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToLinux(type), value);
+        }
+
+        /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, int size, object value)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToLinux(type), size, value);
+        }
+
+        /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, int size, ParameterDirection direction)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToLinux(type), size, direction);
+        }
+
+        /// <inheritdoc />
         public object ReadParam(string parameterName)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
@@ -9,40 +9,77 @@ using System.Data.Common;
 
 namespace OpenDb2.Drivers.Linux
 {
+    /// <summary>
+    /// Linux and macOS DB2 command implementation backed by <see cref="DB2Command"/> (IBM.Data.Db2).
+    /// </summary>
+    /// <param name="command">The underlying <see cref="DB2Command"/> to execute.</param>
     public class LnxDb2Command(DB2Command command) : ILnxDb2Command
     {
         private readonly DB2Command _command = command;
+        private bool _disposed;
 
         /// <inheritdoc />
-        public void AddParam(string parameterName, object value) =>
+        public void AddParam(string parameterName, object value)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             _command.Parameters.Add(parameterName, value);
+        }
 
         /// <inheritdoc />
-        public void AddParam(string parameterName, LnxDb2Type type, object value) =>
+        public void AddParam(string parameterName, LnxDb2Type type, object value)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             _command.Parameters.Add(parameterName, (DB2Type)type).Value = value;
+        }
 
         /// <inheritdoc />
-        public void AddParam(string parameterName, LnxDb2Type type, int size, object value) =>
+        public void AddParam(string parameterName, LnxDb2Type type, int size, object value)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             _command.Parameters.Add(parameterName, (DB2Type)type, size).Value = value;
+        }
 
         /// <inheritdoc />
-        public void AddParam(string parameterName, LnxDb2Type type, int size, ParameterDirection direction) =>
+        public void AddParam(string parameterName, LnxDb2Type type, int size, ParameterDirection direction)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             _command.Parameters.Add(parameterName, (DB2Type)type, size).Direction = direction;
+        }
 
         /// <inheritdoc />
-        public object ReadParam(string parameterName) =>
-            _command.Parameters[parameterName].Value;
+        public object ReadParam(string parameterName)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _command.Parameters[parameterName].Value;
+        }
 
         /// <inheritdoc />
-        public Task<int> ExecuteNonQuery() => _command.ExecuteNonQueryAsync();
+        public Task<int> ExecuteNonQuery()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _command.ExecuteNonQueryAsync();
+        }
 
         /// <inheritdoc />
-        public Task<DbDataReader> ExecuteReader() => _command.ExecuteReaderAsync();
+        public Task<DbDataReader> ExecuteReader()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _command.ExecuteReaderAsync();
+        }
 
         /// <inheritdoc />
-        public DbDataAdapter CreateDataAdapter() => new DB2DataAdapter(_command);
+        public DbDataAdapter CreateDataAdapter()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return new DB2DataAdapter(_command);
+        }
 
         /// <inheritdoc />
-        public void Dispose() => _command.Dispose();
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _command.Dispose();
+        }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
@@ -22,21 +22,21 @@ namespace OpenDb2.Drivers.Linux
         public void AddParam(string parameterName, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, value);
+            _command.Parameters.Add(parameterName, value ?? DBNull.Value);
         }
 
         /// <inheritdoc />
         public void AddParam(string parameterName, LnxDb2Type type, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, (DB2Type)type).Value = value;
+            _command.Parameters.Add(parameterName, (DB2Type)type).Value = value ?? DBNull.Value;
         }
 
         /// <inheritdoc />
         public void AddParam(string parameterName, LnxDb2Type type, int size, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, (DB2Type)type, size).Value = value;
+            _command.Parameters.Add(parameterName, (DB2Type)type, size).Value = value ?? DBNull.Value;
         }
 
         /// <inheritdoc />
@@ -68,21 +68,26 @@ namespace OpenDb2.Drivers.Linux
         public object ReadParam(string parameterName)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
+            ArgumentException.ThrowIfNullOrWhiteSpace(parameterName);
+
+            if (!_command.Parameters.Contains(parameterName))
+                throw new ArgumentException($"Parameter '{parameterName}' not found.", nameof(parameterName));
+
             return _command.Parameters[parameterName].Value;
         }
 
         /// <inheritdoc />
-        public Task<int> ExecuteNonQuery()
+        public Task<int> ExecuteNonQuery(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            return _command.ExecuteNonQueryAsync();
+            return _command.ExecuteNonQueryAsync(cancellationToken);
         }
 
         /// <inheritdoc />
-        public Task<DbDataReader> ExecuteReader()
+        public Task<DbDataReader> ExecuteReader(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            return _command.ExecuteReaderAsync();
+            return _command.ExecuteReaderAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -98,6 +103,7 @@ namespace OpenDb2.Drivers.Linux
             if (_disposed) return;
             _disposed = true;
             _command.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Command.cs
@@ -22,7 +22,8 @@ namespace OpenDb2.Drivers.Linux
         public void AddParam(string parameterName, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, value ?? DBNull.Value);
+            var param = new DB2Parameter(parameterName, value ?? DBNull.Value);
+            _command.Parameters.Add(param);
         }
 
         /// <inheritdoc />

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
@@ -66,6 +66,15 @@ namespace OpenDb2.Drivers.Linux
         }
 
         /// <inheritdoc />
+        IDb2Transaction IDb2Connection.BeginTransaction() => BeginTransaction();
+
+        /// <inheritdoc />
+        IDb2Command IDb2Connection.CreateCommand(string commandText, CommandType commandType) => CreateCommand(commandText, commandType);
+
+        /// <inheritdoc />
+        IDb2Command IDb2Connection.CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction) => CreateCommand(commandText, commandType, transaction);
+
+        /// <inheritdoc />
         public void Dispose()
         {
             if (_disposed) return;

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
@@ -70,6 +70,8 @@ namespace OpenDb2.Drivers.Linux
         {
             if (_disposed) return;
             _disposed = true;
+            if (_connection.State != ConnectionState.Closed)
+                _connection.Close();
             _connection.Dispose();
             GC.SuppressFinalize(this);
         }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
@@ -19,10 +19,10 @@ namespace OpenDb2.Drivers.Linux
         private bool _disposed;
 
         /// <inheritdoc />
-        public async Task Open()
+        public async Task Open(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            await _connection.OpenAsync();
+            await _connection.OpenAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -71,6 +71,7 @@ namespace OpenDb2.Drivers.Linux
             if (_disposed) return;
             _disposed = true;
             _connection.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Connection.cs
@@ -8,22 +8,41 @@ using System.Data;
 
 namespace OpenDb2.Drivers.Linux
 {
+    /// <summary>
+    /// Linux and macOS DB2 connection implementation backed by <see cref="DB2Connection"/> (IBM.Data.Db2).
+    /// Registered as a scoped service via <c>AddLnxDb2Services</c> or <c>AddDb2Services</c> on Linux/macOS.
+    /// </summary>
+    /// <param name="connectionString">The IBM DB2 connection string used to connect to the DB2 instance.</param>
     public class LnxDb2Connection(string connectionString) : ILnxDb2Connection
     {
         private readonly DB2Connection _connection = new(connectionString);
+        private bool _disposed;
 
         /// <inheritdoc />
-        public async Task Open() => await _connection.OpenAsync();
+        public async Task Open()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            await _connection.OpenAsync();
+        }
 
         /// <inheritdoc />
-        public async Task Close() => await _connection.CloseAsync();
+        public async Task Close()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            await _connection.CloseAsync();
+        }
 
         /// <inheritdoc />
-        public ILnxDb2Transaction BeginTransaction() => new LnxDb2Transaction(_connection.BeginTransaction());
+        public ILnxDb2Transaction BeginTransaction()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return new LnxDb2Transaction(_connection.BeginTransaction());
+        }
 
         /// <inheritdoc />
         public ILnxDb2Command CreateCommand(string commandText, CommandType commandType)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             var command = _connection.CreateCommand();
 
             command.CommandText = commandText;
@@ -35,15 +54,23 @@ namespace OpenDb2.Drivers.Linux
         /// <inheritdoc />
         public ILnxDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             var command = _connection.CreateCommand();
 
             command.CommandText = commandText;
             command.CommandType = commandType;
-            command.Transaction = (DB2Transaction)transaction.Transaction;
+            command.Transaction = transaction.Transaction as DB2Transaction
+                ?? throw new InvalidOperationException($"Expected a DB2Transaction but got {transaction.Transaction.GetType().Name}.");
 
             return new LnxDb2Command(command);
         }
 
-        public void Dispose() => _connection.Dispose();
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _connection.Dispose();
+        }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Transaction.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Transaction.cs
@@ -39,6 +39,7 @@ namespace OpenDb2.Drivers.Linux
             if (_disposed) return;
             _disposed = true;
             _transaction.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Transaction.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Linux/LnxDb2Transaction.cs
@@ -7,19 +7,38 @@ using System.Data;
 
 namespace OpenDb2.Drivers.Linux
 {
+    /// <summary>
+    /// Linux and macOS DB2 transaction wrapper around <see cref="DB2Transaction"/>.
+    /// </summary>
+    /// <param name="transaction">The underlying <see cref="DB2Transaction"/>.</param>
     public class LnxDb2Transaction(DB2Transaction transaction) : ILnxDb2Transaction
     {
         private readonly DB2Transaction _transaction = transaction;
+        private bool _disposed;
 
+        /// <inheritdoc />
         public IDbTransaction Transaction => _transaction;
 
         /// <inheritdoc />
-        public void Commit() => _transaction.Commit();
+        public void Commit()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _transaction.Commit();
+        }
 
         /// <inheritdoc />
-        public void Rollback() => _transaction.Rollback();
+        public void Rollback()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _transaction.Rollback();
+        }
 
         /// <inheritdoc />
-        public void Dispose() => _transaction.Dispose();
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _transaction.Dispose();
+        }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Command.cs
@@ -22,21 +22,21 @@ namespace OpenDb2.Drivers.Windows
         public void AddParam(string parameterName, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.AddWithValue(parameterName, value);
+            _command.Parameters.AddWithValue(parameterName, value ?? DBNull.Value);
         }
 
         /// <inheritdoc />
         public void AddParam(string parameterName, WinDb2Type type, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, (OleDbType)type).Value = value;
+            _command.Parameters.Add(parameterName, (OleDbType)type).Value = value ?? DBNull.Value;
         }
 
         /// <inheritdoc />
         public void AddParam(string parameterName, WinDb2Type type, int size, object value)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            _command.Parameters.Add(parameterName, (OleDbType)type, size).Value = value;
+            _command.Parameters.Add(parameterName, (OleDbType)type, size).Value = value ?? DBNull.Value;
         }
 
         /// <inheritdoc />
@@ -68,21 +68,26 @@ namespace OpenDb2.Drivers.Windows
         public object ReadParam(string parameterName)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
+            ArgumentException.ThrowIfNullOrWhiteSpace(parameterName);
+
+            if (!_command.Parameters.Contains(parameterName))
+                throw new ArgumentException($"Parameter '{parameterName}' not found.", nameof(parameterName));
+
             return _command.Parameters[parameterName].Value;
         }
 
         /// <inheritdoc />
-        public Task<int> ExecuteNonQuery()
+        public Task<int> ExecuteNonQuery(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            return _command.ExecuteNonQueryAsync();
+            return _command.ExecuteNonQueryAsync(cancellationToken);
         }
 
         /// <inheritdoc />
-        public Task<DbDataReader> ExecuteReader()
+        public Task<DbDataReader> ExecuteReader(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            return _command.ExecuteReaderAsync();
+            return _command.ExecuteReaderAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -98,6 +103,7 @@ namespace OpenDb2.Drivers.Windows
             if (_disposed) return;
             _disposed = true;
             _command.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Command.cs
@@ -47,6 +47,24 @@ namespace OpenDb2.Drivers.Windows
         }
 
         /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, object value)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToWindows(type), value);
+        }
+
+        /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, int size, object value)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToWindows(type), size, value);
+        }
+
+        /// <inheritdoc />
+        public void AddParam(string parameterName, Db2Type type, int size, ParameterDirection direction)
+        {
+            AddParam(parameterName, Db2TypeMapper.ToWindows(type), size, direction);
+        }
+
+        /// <inheritdoc />
         public object ReadParam(string parameterName)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Command.cs
@@ -9,39 +9,77 @@ using System.Data.OleDb;
 
 namespace OpenDb2.Drivers.Windows
 {
+    /// <summary>
+    /// Windows-specific DB2 command implementation backed by <see cref="OleDbCommand"/>.
+    /// </summary>
+    /// <param name="command">The underlying <see cref="OleDbCommand"/> to execute.</param>
     public class WinDb2Command(OleDbCommand command) : IWinDb2Command
     {
         private readonly OleDbCommand _command = command;
+        private bool _disposed;
 
         /// <inheritdoc />
-        public void AddParam(string parameterName, object value) =>
+        public void AddParam(string parameterName, object value)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             _command.Parameters.AddWithValue(parameterName, value);
+        }
 
         /// <inheritdoc />
-        public void AddParam(string parameterName, WinDb2Type type, object value) =>
+        public void AddParam(string parameterName, WinDb2Type type, object value)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             _command.Parameters.Add(parameterName, (OleDbType)type).Value = value;
+        }
 
         /// <inheritdoc />
-        public void AddParam(string parameterName, WinDb2Type type, int size, object value) =>
+        public void AddParam(string parameterName, WinDb2Type type, int size, object value)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             _command.Parameters.Add(parameterName, (OleDbType)type, size).Value = value;
+        }
 
         /// <inheritdoc />
-        public void AddParam(string parameterName, WinDb2Type type, int size, ParameterDirection direction) =>
+        public void AddParam(string parameterName, WinDb2Type type, int size, ParameterDirection direction)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             _command.Parameters.Add(parameterName, (OleDbType)type, size).Direction = direction;
+        }
 
         /// <inheritdoc />
-        public object ReadParam(string parameterName) =>
-            _command.Parameters[parameterName].Value;
-
-        public Task<int> ExecuteNonQuery() => _command.ExecuteNonQueryAsync();
-
-        /// <inheritdoc />
-        public Task<DbDataReader> ExecuteReader() => _command.ExecuteReaderAsync();
+        public object ReadParam(string parameterName)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _command.Parameters[parameterName].Value;
+        }
 
         /// <inheritdoc />
-        public DbDataAdapter CreateDataAdapter() => new OleDbDataAdapter(_command);
+        public Task<int> ExecuteNonQuery()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _command.ExecuteNonQueryAsync();
+        }
 
         /// <inheritdoc />
-        public void Dispose() => _command.Dispose();
+        public Task<DbDataReader> ExecuteReader()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _command.ExecuteReaderAsync();
+        }
+
+        /// <inheritdoc />
+        public DbDataAdapter CreateDataAdapter()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return new OleDbDataAdapter(_command);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _command.Dispose();
+        }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
@@ -8,22 +8,41 @@ using System.Data.OleDb;
 
 namespace OpenDb2.Drivers.Windows
 {
+    /// <summary>
+    /// Windows-specific DB2 connection implementation backed by <see cref="OleDbConnection"/>.
+    /// Registered as a scoped service via <c>AddWinDb2Services</c> or <c>AddDb2Services</c> on Windows.
+    /// </summary>
+    /// <param name="connectionString">The OleDb connection string used to connect to the DB2 instance.</param>
     public class WinDb2Connection(string connectionString) : IWinDb2Connection
     {
         private readonly OleDbConnection _connection = new(connectionString);
+        private bool _disposed;
 
         /// <inheritdoc />
-        public async Task Open() => await _connection.OpenAsync();
+        public async Task Open()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            await _connection.OpenAsync();
+        }
 
         /// <inheritdoc />
-        public async Task Close() => await _connection.CloseAsync();
+        public async Task Close()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            await _connection.CloseAsync();
+        }
 
         /// <inheritdoc />
-        public IWinDb2Transaction BeginTransaction() => new WinDb2Transaction(_connection.BeginTransaction());
+        public IWinDb2Transaction BeginTransaction()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return new WinDb2Transaction(_connection.BeginTransaction());
+        }
 
         /// <inheritdoc />
         public IWinDb2Command CreateCommand(string commandText, CommandType commandType)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             var command = _connection.CreateCommand();
 
             command.CommandText = commandText;
@@ -35,15 +54,23 @@ namespace OpenDb2.Drivers.Windows
         /// <inheritdoc />
         public IWinDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             var command = _connection.CreateCommand();
 
             command.CommandText = commandText;
             command.CommandType = commandType;
-            command.Transaction = (OleDbTransaction)transaction.Transaction;
+            command.Transaction = transaction.Transaction as OleDbTransaction
+                ?? throw new InvalidOperationException($"Expected an OleDbTransaction but got {transaction.Transaction.GetType().Name}.");
 
             return new WinDb2Command(command);
         }
 
-        public void Dispose() => _connection.Dispose();
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _connection.Dispose();
+        }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
@@ -66,6 +66,15 @@ namespace OpenDb2.Drivers.Windows
         }
 
         /// <inheritdoc />
+        IDb2Transaction IDb2Connection.BeginTransaction() => BeginTransaction();
+
+        /// <inheritdoc />
+        IDb2Command IDb2Connection.CreateCommand(string commandText, CommandType commandType) => CreateCommand(commandText, commandType);
+
+        /// <inheritdoc />
+        IDb2Command IDb2Connection.CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction) => CreateCommand(commandText, commandType, transaction);
+
+        /// <inheritdoc />
         public void Dispose()
         {
             if (_disposed) return;

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
@@ -19,10 +19,10 @@ namespace OpenDb2.Drivers.Windows
         private bool _disposed;
 
         /// <inheritdoc />
-        public async Task Open()
+        public async Task Open(CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            await _connection.OpenAsync();
+            await _connection.OpenAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -71,6 +71,7 @@ namespace OpenDb2.Drivers.Windows
             if (_disposed) return;
             _disposed = true;
             _connection.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Connection.cs
@@ -70,6 +70,8 @@ namespace OpenDb2.Drivers.Windows
         {
             if (_disposed) return;
             _disposed = true;
+            if (_connection.State != ConnectionState.Closed)
+                _connection.Close();
             _connection.Dispose();
             GC.SuppressFinalize(this);
         }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Transaction.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Transaction.cs
@@ -7,19 +7,38 @@ using System.Data.OleDb;
 
 namespace OpenDb2.Drivers.Windows
 {
+    /// <summary>
+    /// Windows-specific DB2 transaction wrapper around <see cref="OleDbTransaction"/>.
+    /// </summary>
+    /// <param name="transaction">The underlying <see cref="OleDbTransaction"/>.</param>
     public class WinDb2Transaction(OleDbTransaction transaction) : IWinDb2Transaction
     {
         private readonly OleDbTransaction _transaction = transaction;
+        private bool _disposed;
 
+        /// <inheritdoc />
         public IDbTransaction Transaction => _transaction;
 
         /// <inheritdoc />
-        public void Commit() => _transaction.Commit();
+        public void Commit()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _transaction.Commit();
+        }
 
         /// <inheritdoc />
-        public void Rollback() => _transaction.Rollback();
+        public void Rollback()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _transaction.Rollback();
+        }
 
         /// <inheritdoc />
-        public void Dispose() => _transaction.Dispose();
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _transaction.Dispose();
+        }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Transaction.cs
+++ b/src/Ninja.Sharp.OpenDb2/Drivers/Windows/WinDb2Transaction.cs
@@ -39,6 +39,7 @@ namespace OpenDb2.Drivers.Windows
             if (_disposed) return;
             _disposed = true;
             _transaction.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Enums/Db2Type.cs
+++ b/src/Ninja.Sharp.OpenDb2/Enums/Db2Type.cs
@@ -1,0 +1,33 @@
+// (c) 2024 thesharpninjas
+// This code is licensed under MIT license (see LICENSE.txt for details)
+
+namespace OpenDb2.Enums
+{
+    /// <summary>
+    /// Platform-agnostic DB2 data types. These are automatically mapped at runtime
+    /// to the appropriate platform-specific type (<see cref="WinDb2Type"/> or <see cref="LnxDb2Type"/>).
+    /// </summary>
+    public enum Db2Type
+    {
+        SmallInt,
+        Integer,
+        BigInt,
+        Real,
+        Double,
+        Decimal,
+        Numeric,
+        Char,
+        VarChar,
+        LongVarChar,
+        Binary,
+        VarBinary,
+        LongVarBinary,
+        Date,
+        Time,
+        Timestamp,
+        Clob,
+        Blob,
+        Xml,
+        Boolean
+    }
+}

--- a/src/Ninja.Sharp.OpenDb2/Enums/LnxDb2Type.cs
+++ b/src/Ninja.Sharp.OpenDb2/Enums/LnxDb2Type.cs
@@ -1,4 +1,4 @@
-﻿// (c) 2024 thesharpninjas
+// (c) 2024 thesharpninjas
 // This code is licensed under MIT license (see LICENSE.txt for details)
 
 namespace OpenDb2.Enums
@@ -46,29 +46,29 @@ namespace OpenDb2.Enums
         DateTime = 38,
         Text = 39,
         Byte = 40,
-        [Obsolete("Current incompatabality between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
+        [Obsolete("Current incompatibility between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
         Char1 = 1001,
         SmallFloat = 1002,
         Null = 1003,
-        [Obsolete("Current incompatabality between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
+        [Obsolete("Current incompatibility between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
         IntervalYearMonth = 1004,
-        [Obsolete("Current incompatabality between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
+        [Obsolete("Current incompatibility between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
         IntervalDayFraction = 1005,
         NChar = 1006,
         NVarChar = 1007,
-        [Obsolete("Current incompatabality between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
+        [Obsolete("Current incompatibility between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
         Set = 1008,
-        [Obsolete("Current incompatabality between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
+        [Obsolete("Current incompatibility between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
         MultiSet = 1009,
-        [Obsolete("Current incompatabality between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
+        [Obsolete("Current incompatibility between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
         List = 1010,
-        [Obsolete("Current incompatabality between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
+        [Obsolete("Current incompatibility between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
         Row = 1011,
-        [Obsolete("Current incompatabality between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
+        [Obsolete("Current incompatibility between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
         SQLUDTVar = 1012,
-        [Obsolete("Current incompatabality between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
+        [Obsolete("Current incompatibility between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
         SQLUDTFixed = 1013,
-        [Obsolete("Current incompatabality between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
+        [Obsolete("Current incompatibility between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider")]
         SmartLobLocator = 1014,
         Boolean = 1015,
         Other = 1016

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Command.cs
@@ -56,14 +56,16 @@ namespace OpenDb2.Interfaces
         /// <summary>
         /// Executes the command against the database and returns the number of rows affected.
         /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A task representing the asynchronous operation, with a result of the number of rows affected.</returns>
-        Task<int> ExecuteNonQuery();
+        Task<int> ExecuteNonQuery(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes the command against the database and returns a data reader for reading the results.
         /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A task representing the asynchronous operation, with a result of a <see cref="DbDataReader"/> object for reading the results.</returns>
-        Task<DbDataReader> ExecuteReader();
+        Task<DbDataReader> ExecuteReader(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a data adapter for use with the command.

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Command.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Command.cs
@@ -1,6 +1,8 @@
 ﻿// (c) 2024 thesharpninjas
 // This code is licensed under MIT license (see LICENSE.txt for details)
 
+using OpenDb2.Enums;
+using System.Data;
 using System.Data.Common;
 
 namespace OpenDb2.Interfaces
@@ -16,6 +18,33 @@ namespace OpenDb2.Interfaces
         /// <param name="parameterName">The name of the parameter to add.</param>
         /// <param name="value">The value of the parameter to add.</param>
         void AddParam(string parameterName, object value);
+
+        /// <summary>
+        /// Adds a parameter using a platform-agnostic <see cref="Db2Type"/> that is automatically
+        /// mapped to the correct platform-specific type at runtime.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter to add.</param>
+        /// <param name="type">The platform-agnostic data type.</param>
+        /// <param name="value">The value of the parameter.</param>
+        void AddParam(string parameterName, Db2Type type, object value);
+
+        /// <summary>
+        /// Adds a parameter using a platform-agnostic <see cref="Db2Type"/> with a specified size.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter to add.</param>
+        /// <param name="type">The platform-agnostic data type.</param>
+        /// <param name="size">The size of the parameter.</param>
+        /// <param name="value">The value of the parameter.</param>
+        void AddParam(string parameterName, Db2Type type, int size, object value);
+
+        /// <summary>
+        /// Adds a parameter using a platform-agnostic <see cref="Db2Type"/> with a specified size and direction.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter to add.</param>
+        /// <param name="type">The platform-agnostic data type.</param>
+        /// <param name="size">The size of the parameter.</param>
+        /// <param name="direction">The direction of the parameter.</param>
+        void AddParam(string parameterName, Db2Type type, int size, ParameterDirection direction);
 
         /// <summary>
         /// Retrieves the value of a parameter with the specified name.

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Connection.cs
@@ -11,8 +11,9 @@ namespace OpenDb2.Interfaces
         /// <summary>
         /// Asynchronously opens the DB2 database connection.
         /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        Task Open();
+        Task Open(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously closes the DB2 database connection.

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/IDb2Connection.cs
@@ -1,6 +1,8 @@
 ﻿// (c) 2024 thesharpninjas
 // This code is licensed under MIT license (see LICENSE.txt for details)
 
+using System.Data;
+
 namespace OpenDb2.Interfaces
 {
     /// <summary>
@@ -20,5 +22,28 @@ namespace OpenDb2.Interfaces
         /// </summary>
         /// <returns>A task representing the asynchronous operation.</returns>
         Task Close();
+
+        /// <summary>
+        /// Begins a new transaction on the DB2 connection.
+        /// </summary>
+        /// <returns>An instance of <see cref="IDb2Transaction"/> representing the new transaction.</returns>
+        IDb2Transaction BeginTransaction();
+
+        /// <summary>
+        /// Creates a new command to be executed against the DB2 database.
+        /// </summary>
+        /// <param name="commandText">The query or stored procedure to execute.</param>
+        /// <param name="commandType">The type of command (e.g., Text, StoredProcedure).</param>
+        /// <returns>An instance of <see cref="IDb2Command"/> representing the new command.</returns>
+        IDb2Command CreateCommand(string commandText, CommandType commandType);
+
+        /// <summary>
+        /// Creates a new command to be executed against the DB2 database within the context of a transaction.
+        /// </summary>
+        /// <param name="commandText">The query or stored procedure to execute.</param>
+        /// <param name="commandType">The type of command (e.g., Text, StoredProcedure).</param>
+        /// <param name="transaction">The transaction within which the command should execute.</param>
+        /// <returns>An instance of <see cref="IDb2Command"/> representing the new command.</returns>
+        IDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction);
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/IEnvironmentDetector.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/IEnvironmentDetector.cs
@@ -5,10 +5,24 @@ using System.Runtime.InteropServices;
 
 namespace Ninja.Sharp.OpenDb2.Interfaces
 {
+    /// <summary>
+    /// Detects the operating system platform at runtime.
+    /// </summary>
     public interface IEnvironmentDetector
     {
+        /// <summary>
+        /// Returns the current <see cref="OSPlatform"/> (Windows, Linux, OSX, or a custom "Other" value).
+        /// </summary>
         OSPlatform GetCurrentOSPlatform();
+
+        /// <summary>
+        /// Returns <see langword="true"/> when running on Windows.
+        /// </summary>
         bool IsWindows();
+
+        /// <summary>
+        /// Returns <see langword="true"/> when running on Linux.
+        /// </summary>
         bool IsLinux();
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/Linux/ILnxDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/Linux/ILnxDb2Connection.cs
@@ -14,7 +14,7 @@ namespace OpenDb2.Interfaces.Linux
         /// Begins a new transaction on the DB2 connection.
         /// </summary>
         /// <returns>A new instance of <see cref="ILnxDb2Transaction"/> representing the transaction.</returns>
-        ILnxDb2Transaction BeginTransaction();
+        new ILnxDb2Transaction BeginTransaction();
 
         /// <summary>
         /// Creates a new command with the specified command text and type.
@@ -22,7 +22,7 @@ namespace OpenDb2.Interfaces.Linux
         /// <param name="commandText">The query or stored procedure name to execute.</param>
         /// <param name="commandType">The type of command (e.g., Text, StoredProcedure, TableDirect).</param>
         /// <returns>A new instance of <see cref="ILnxDb2Command"/> configured with the specified command text and type.</returns>
-        ILnxDb2Command CreateCommand(string commandText, CommandType commandType);
+        new ILnxDb2Command CreateCommand(string commandText, CommandType commandType);
 
         /// <summary>
         /// Creates a new command with the specified command text, type, and transaction.
@@ -31,6 +31,6 @@ namespace OpenDb2.Interfaces.Linux
         /// <param name="commandType">The type of command (e.g., Text, StoredProcedure, TableDirect).</param>
         /// <param name="transaction">The transaction within which the command executes.</param>
         /// <returns>A new instance of <see cref="ILnxDb2Command"/> configured with the specified parameters.</returns>
-        ILnxDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction);
+        new ILnxDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction);
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Interfaces/Windows/IWinDb2Connection.cs
+++ b/src/Ninja.Sharp.OpenDb2/Interfaces/Windows/IWinDb2Connection.cs
@@ -14,7 +14,7 @@ namespace OpenDb2.Interfaces.Windows
         /// Begins a new transaction on the DB2 connection.
         /// </summary>
         /// <returns>An instance of <see cref="IWinDb2Transaction"/> representing the new transaction.</returns>
-        IWinDb2Transaction BeginTransaction();
+        new IWinDb2Transaction BeginTransaction();
 
         /// <summary>
         /// Creates a new command to be executed against the DB2 database.
@@ -22,7 +22,7 @@ namespace OpenDb2.Interfaces.Windows
         /// <param name="commandText">The query or stored procedure to execute.</param>
         /// <param name="commandType">The type of command (e.g., Text, StoredProcedure).</param>
         /// <returns>An instance of <see cref="IWinDb2Command"/> representing the new command.</returns>
-        IWinDb2Command CreateCommand(string commandText, CommandType commandType);
+        new IWinDb2Command CreateCommand(string commandText, CommandType commandType);
 
         /// <summary>
         /// Creates a new command to be executed against the DB2 database within the context of a transaction.
@@ -31,6 +31,6 @@ namespace OpenDb2.Interfaces.Windows
         /// <param name="commandType">The type of command (e.g., Text, StoredProcedure).</param>
         /// <param name="transaction">The transaction within which the command should execute.</param>
         /// <returns>An instance of <see cref="IWinDb2Command"/> representing the new command.</returns>
-        IWinDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction);
+        new IWinDb2Command CreateCommand(string commandText, CommandType commandType, IDb2Transaction transaction);
     }
 }

--- a/src/Ninja.Sharp.OpenDb2/Ninja.Sharp.OpenDb2.csproj
+++ b/src/Ninja.Sharp.OpenDb2/Ninja.Sharp.OpenDb2.csproj
@@ -37,17 +37,24 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="System.Data.OleDb" Version="10.0.7" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Net.IBM.Data.Db2-lnx" Version="10.0.0.100" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
+    <PackageReference Include="System.Data.OleDb" Version="9.0.7" />
+    <PackageReference Include="Net.IBM.Data.Db2-lnx" Version="9.0.0.400" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="System.Data.OleDb" Version="8.0.1" />
     <PackageReference Include="Net.IBM.Data.Db2-lnx" Version="9.0.0.400" />
   </ItemGroup>
 

--- a/src/Ninja.Sharp.OpenDb2/Ninja.Sharp.OpenDb2.csproj
+++ b/src/Ninja.Sharp.OpenDb2/Ninja.Sharp.OpenDb2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -10,10 +10,10 @@
 	<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 	<Company>The Sharp Ninjas</Company>
 	<Authors>The Sharp Ninjas</Authors>
-	<Version>1.2.0</Version>
-	<AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
-    <InformationalVersion>1.2.0</InformationalVersion>
+	<Version>1.3.0</Version>
+	<AssemblyVersion>1.3.0.0</AssemblyVersion>
+	<FileVersion>1.3.0.0</FileVersion>
+	<InformationalVersion>1.3.0</InformationalVersion>
     <RootNamespace>Ninja.Sharp.OpenDb2</RootNamespace>
 	<Description>A lightweight .NET client library that simplifies working with IBM DB2 databases</Description>
 	<PackageTags>DB2, OleDb, Sql</PackageTags>
@@ -38,10 +38,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
-    <PackageReference Include="Net.IBM.Data.Db2-lnx" Version="9.0.0.300" />
-    <PackageReference Include="System.Data.OleDb" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="System.Data.OleDb" Version="10.0.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Net.IBM.Data.Db2-lnx" Version="10.0.0.100" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Net.IBM.Data.Db2-lnx" Version="9.0.0.400" />
   </ItemGroup>
 
 </Project>

--- a/src/Ninja.Sharp.OpenDb2/Services/ServiceRegistration.cs
+++ b/src/Ninja.Sharp.OpenDb2/Services/ServiceRegistration.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Ninja.Sharp.OpenDb2.Interfaces;
 using Ninja.Sharp.OpenDb2.Utilities;
+using OpenDb2.Interfaces;
 using OpenDb2.Drivers.Linux;
 using OpenDb2.Drivers.Windows;
 using OpenDb2.Interfaces.Linux;
@@ -63,12 +64,15 @@ namespace OpenDb2.Services
             {
                 case var os when os == OSPlatform.Windows:
                     services.AddScoped<IWinDb2Connection>(sp => new WinDb2Connection(connectionString));
+                    services.AddScoped<IDb2Connection>(sp => sp.GetRequiredService<IWinDb2Connection>());
                     break;
                 case var os when os == OSPlatform.Linux:
                     services.AddScoped<ILnxDb2Connection>(sp => new LnxDb2Connection(connectionString));
+                    services.AddScoped<IDb2Connection>(sp => sp.GetRequiredService<ILnxDb2Connection>());
                     break;
                 case var os when os == OSPlatform.OSX:
                     services.AddScoped<ILnxDb2Connection>(sp => new LnxDb2Connection(connectionString));
+                    services.AddScoped<IDb2Connection>(sp => sp.GetRequiredService<ILnxDb2Connection>());
                     break;
                 default:
                     throw new NotSupportedException("Unsupported operating system platform.");
@@ -93,6 +97,7 @@ namespace OpenDb2.Services
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
             services.AddScoped<IWinDb2Connection>(sp => new WinDb2Connection(connectionString));
+            services.AddScoped<IDb2Connection>(sp => sp.GetRequiredService<IWinDb2Connection>());
 
             return services;
         }
@@ -113,6 +118,7 @@ namespace OpenDb2.Services
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
             services.AddScoped<ILnxDb2Connection>(sp => new LnxDb2Connection(connectionString));
+            services.AddScoped<IDb2Connection>(sp => sp.GetRequiredService<ILnxDb2Connection>());
 
             return services;
         }

--- a/src/Ninja.Sharp.OpenDb2/Services/ServiceRegistration.cs
+++ b/src/Ninja.Sharp.OpenDb2/Services/ServiceRegistration.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Ninja.Sharp.OpenDb2.Interfaces;
 using Ninja.Sharp.OpenDb2.Utilities;
 using OpenDb2.Drivers.Linux;
 using OpenDb2.Drivers.Windows;
@@ -12,27 +13,53 @@ using System.Runtime.InteropServices;
 
 namespace OpenDb2.Services
 {
+    /// <summary>
+    /// Provides extension methods on <see cref="IServiceCollection"/> for registering DB2 connection services.
+    /// </summary>
     public static class ServiceRegistration
     {
         /// <summary>
-        /// Registers the Db2 services based on the current operating system platform.
+        /// Registers the appropriate DB2 connection as a scoped service based on the current operating system.
+        /// On Windows it registers <see cref="IWinDb2Connection"/>; on Linux and macOS it registers <see cref="ILnxDb2Connection"/>.
         /// </summary>
-        /// <param name="services"></param>
-        /// <param name="connectionString"></param>
-        /// <param name="config"></param>
-        /// <returns></returns>
-        /// <exception cref="NotSupportedException"></exception>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+        /// <param name="connectionString">The DB2 connection string.</param>
+        /// <param name="config">The application configuration (reserved for future use).</param>
+        /// <returns>The same <see cref="IServiceCollection"/> instance for chaining.</returns>
+        /// <exception cref="NotSupportedException">Thrown when the current OS platform is not supported.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString"/> is null, empty, or whitespace.</exception>
         public static IServiceCollection AddDb2Services(
             this IServiceCollection services, 
             string connectionString, 
             IConfiguration config)
         {
-            ConfigurationBuilder builder = new();
+            return AddDb2Services(services, connectionString, config, new EnvironmentDetector());
+        }
 
-            builder.AddConfiguration(config);
-            builder.Build();
+        /// <summary>
+        /// Registers the appropriate DB2 connection as a scoped service based on the detected operating system.
+        /// This overload accepts an <see cref="IEnvironmentDetector"/> for testability.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+        /// <param name="connectionString">The DB2 connection string.</param>
+        /// <param name="config">The application configuration (reserved for future use).</param>
+        /// <param name="environmentDetector">The detector used to identify the current OS platform.</param>
+        /// <returns>The same <see cref="IServiceCollection"/> instance for chaining.</returns>
+        /// <exception cref="NotSupportedException">Thrown when the current OS platform is not supported.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="environmentDetector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString"/> is null, empty, or whitespace.</exception>
+        public static IServiceCollection AddDb2Services(
+            this IServiceCollection services,
+            string connectionString,
+            IConfiguration config,
+            IEnvironmentDetector environmentDetector)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+            ArgumentNullException.ThrowIfNull(environmentDetector);
 
-            switch (new EnvironmentDetector().GetCurrentOSPlatform())
+            switch (environmentDetector.GetCurrentOSPlatform())
             {
                 case var os when os == OSPlatform.Windows:
                     services.AddScoped<IWinDb2Connection>(sp => new WinDb2Connection(connectionString));
@@ -51,18 +78,19 @@ namespace OpenDb2.Services
         }
 
         /// <summary>
-        /// Registers the Db2 services for Windows environment.
+        /// Registers <see cref="IWinDb2Connection"/> as a scoped service for Windows environments.
+        /// Use this method when the application is known to run exclusively on Windows.
         /// </summary>
-        /// <param name="services"></param>
-        /// <param name="connectionString"></param>
-        /// <param name="config"></param>
-        /// <returns></returns>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+        /// <param name="connectionString">The OleDb connection string for the DB2 instance.</param>
+        /// <param name="config">The application configuration (reserved for future use).</param>
+        /// <returns>The same <see cref="IServiceCollection"/> instance for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString"/> is null, empty, or whitespace.</exception>
         public static IServiceCollection AddWinDb2Services(this IServiceCollection services, string connectionString, IConfiguration config)
         {
-            ConfigurationBuilder builder = new();
-
-            builder.AddConfiguration(config);
-            builder.Build();
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
             services.AddScoped<IWinDb2Connection>(sp => new WinDb2Connection(connectionString));
 
@@ -70,18 +98,19 @@ namespace OpenDb2.Services
         }
 
         /// <summary>
-        /// Registers the Db2 services for Linux environment.
+        /// Registers <see cref="ILnxDb2Connection"/> as a scoped service for Linux and macOS environments.
+        /// Use this method when the application is known to run exclusively on Linux or macOS.
         /// </summary>
-        /// <param name="services"></param>
-        /// <param name="connectionString"></param>
-        /// <param name="config"></param>
-        /// <returns></returns>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+        /// <param name="connectionString">The IBM DB2 connection string for the DB2 instance.</param>
+        /// <param name="config">The application configuration (reserved for future use).</param>
+        /// <returns>The same <see cref="IServiceCollection"/> instance for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString"/> is null, empty, or whitespace.</exception>
         public static IServiceCollection AddLnxDb2Services(this IServiceCollection services, string connectionString, IConfiguration config)
         {
-            ConfigurationBuilder builder = new();
-
-            builder.AddConfiguration(config);
-            builder.Build();
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
             services.AddScoped<ILnxDb2Connection>(sp => new LnxDb2Connection(connectionString));
 

--- a/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
+++ b/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
@@ -1,0 +1,85 @@
+// (c) 2024 thesharpninjas
+// This code is licensed under MIT license (see LICENSE.txt for details)
+
+using Ninja.Sharp.OpenDb2.Interfaces;
+using System.Collections.Frozen;
+
+namespace OpenDb2.Enums
+{
+    /// <summary>
+    /// Maps platform-agnostic <see cref="Db2Type"/> values to the corresponding
+    /// <see cref="WinDb2Type"/> or <see cref="LnxDb2Type"/> at runtime based on the current OS.
+    /// </summary>
+    public static class Db2TypeMapper
+    {
+        private static readonly FrozenDictionary<Db2Type, WinDb2Type> s_toWin = new Dictionary<Db2Type, WinDb2Type>
+        {
+            [Db2Type.SmallInt] = WinDb2Type.SmallInt,
+            [Db2Type.Integer] = WinDb2Type.Integer,
+            [Db2Type.BigInt] = WinDb2Type.BigInt,
+            [Db2Type.Real] = WinDb2Type.Single,
+            [Db2Type.Double] = WinDb2Type.Double,
+            [Db2Type.Decimal] = WinDb2Type.Decimal,
+            [Db2Type.Numeric] = WinDb2Type.Numeric,
+            [Db2Type.Char] = WinDb2Type.Char,
+            [Db2Type.VarChar] = WinDb2Type.VarChar,
+            [Db2Type.LongVarChar] = WinDb2Type.LongVarChar,
+            [Db2Type.Binary] = WinDb2Type.Binary,
+            [Db2Type.VarBinary] = WinDb2Type.VarBinary,
+            [Db2Type.LongVarBinary] = WinDb2Type.LongVarBinary,
+            [Db2Type.Date] = WinDb2Type.DBDate,
+            [Db2Type.Time] = WinDb2Type.DBTime,
+            [Db2Type.Timestamp] = WinDb2Type.DBTimeStamp,
+            [Db2Type.Clob] = WinDb2Type.LongVarWChar,
+            [Db2Type.Blob] = WinDb2Type.LongVarBinary,
+            [Db2Type.Xml] = WinDb2Type.LongVarWChar,
+            [Db2Type.Boolean] = WinDb2Type.Boolean,
+        }.ToFrozenDictionary();
+
+        private static readonly FrozenDictionary<Db2Type, LnxDb2Type> s_toLnx = new Dictionary<Db2Type, LnxDb2Type>
+        {
+            [Db2Type.SmallInt] = LnxDb2Type.SmallInt,
+            [Db2Type.Integer] = LnxDb2Type.Integer,
+            [Db2Type.BigInt] = LnxDb2Type.BigInt,
+            [Db2Type.Real] = LnxDb2Type.Real,
+            [Db2Type.Double] = LnxDb2Type.Double,
+            [Db2Type.Decimal] = LnxDb2Type.Decimal,
+            [Db2Type.Numeric] = LnxDb2Type.Numeric,
+            [Db2Type.Char] = LnxDb2Type.Char,
+            [Db2Type.VarChar] = LnxDb2Type.VarChar,
+            [Db2Type.LongVarChar] = LnxDb2Type.LongVarChar,
+            [Db2Type.Binary] = LnxDb2Type.Binary,
+            [Db2Type.VarBinary] = LnxDb2Type.VarBinary,
+            [Db2Type.LongVarBinary] = LnxDb2Type.LongVarBinary,
+            [Db2Type.Date] = LnxDb2Type.Date,
+            [Db2Type.Time] = LnxDb2Type.Time,
+            [Db2Type.Timestamp] = LnxDb2Type.Timestamp,
+            [Db2Type.Clob] = LnxDb2Type.Clob,
+            [Db2Type.Blob] = LnxDb2Type.Blob,
+            [Db2Type.Xml] = LnxDb2Type.Xml,
+            [Db2Type.Boolean] = LnxDb2Type.Boolean,
+        }.ToFrozenDictionary();
+
+        /// <summary>
+        /// Converts a <see cref="Db2Type"/> to the corresponding <see cref="WinDb2Type"/>.
+        /// </summary>
+        /// <exception cref="NotSupportedException">Thrown when the type has no Windows mapping.</exception>
+        public static WinDb2Type ToWindows(Db2Type type)
+        {
+            return s_toWin.TryGetValue(type, out var result)
+                ? result
+                : throw new NotSupportedException($"Db2Type '{type}' has no Windows (OleDb) mapping.");
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Db2Type"/> to the corresponding <see cref="LnxDb2Type"/>.
+        /// </summary>
+        /// <exception cref="NotSupportedException">Thrown when the type has no Linux mapping.</exception>
+        public static LnxDb2Type ToLinux(Db2Type type)
+        {
+            return s_toLnx.TryGetValue(type, out var result)
+                ? result
+                : throw new NotSupportedException($"Db2Type '{type}' has no Linux (IBM.Data.Db2) mapping.");
+        }
+    }
+}

--- a/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
+++ b/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
@@ -1,7 +1,6 @@
 // (c) 2024 thesharpninjas
 // This code is licensed under MIT license (see LICENSE.txt for details)
 
-using Ninja.Sharp.OpenDb2.Interfaces;
 using System.Collections.Frozen;
 
 namespace OpenDb2.Enums
@@ -12,6 +11,18 @@ namespace OpenDb2.Enums
     /// </summary>
     public static class Db2TypeMapper
     {
+        static Db2TypeMapper()
+        {
+            var allValues = Enum.GetValues<Db2Type>();
+            foreach (var value in allValues)
+            {
+                if (!s_toWin.ContainsKey(value))
+                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Windows (OleDb) mapping in {nameof(Db2TypeMapper)}.");
+                if (!s_toLnx.ContainsKey(value))
+                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Linux (IBM.Data.Db2) mapping in {nameof(Db2TypeMapper)}.");
+            }
+        }
+
         private static readonly FrozenDictionary<Db2Type, WinDb2Type> s_toWin = new Dictionary<Db2Type, WinDb2Type>
         {
             [Db2Type.SmallInt] = WinDb2Type.SmallInt,
@@ -30,9 +41,9 @@ namespace OpenDb2.Enums
             [Db2Type.Date] = WinDb2Type.DBDate,
             [Db2Type.Time] = WinDb2Type.DBTime,
             [Db2Type.Timestamp] = WinDb2Type.DBTimeStamp,
-            [Db2Type.Clob] = WinDb2Type.LongVarWChar,
-            [Db2Type.Blob] = WinDb2Type.LongVarBinary,
-            [Db2Type.Xml] = WinDb2Type.LongVarWChar,
+            [Db2Type.Clob] = WinDb2Type.LongVarWChar,  // OleDb has no native CLOB; mapped to LongVarWChar (same as Xml)
+            [Db2Type.Blob] = WinDb2Type.LongVarBinary,  // OleDb has no native BLOB; mapped to LongVarBinary (same as LongVarBinary)
+            [Db2Type.Xml] = WinDb2Type.LongVarWChar,    // OleDb has no native XML; mapped to LongVarWChar (same as Clob)
             [Db2Type.Boolean] = WinDb2Type.Boolean,
         }.ToFrozenDictionary();
 

--- a/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
+++ b/src/Ninja.Sharp.OpenDb2/Utilities/Db2TypeMapper.cs
@@ -11,18 +11,6 @@ namespace OpenDb2.Enums
     /// </summary>
     public static class Db2TypeMapper
     {
-        static Db2TypeMapper()
-        {
-            var allValues = Enum.GetValues<Db2Type>();
-            foreach (var value in allValues)
-            {
-                if (!s_toWin.ContainsKey(value))
-                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Windows (OleDb) mapping in {nameof(Db2TypeMapper)}.");
-                if (!s_toLnx.ContainsKey(value))
-                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Linux (IBM.Data.Db2) mapping in {nameof(Db2TypeMapper)}.");
-            }
-        }
-
         private static readonly FrozenDictionary<Db2Type, WinDb2Type> s_toWin = new Dictionary<Db2Type, WinDb2Type>
         {
             [Db2Type.SmallInt] = WinDb2Type.SmallInt,
@@ -70,6 +58,18 @@ namespace OpenDb2.Enums
             [Db2Type.Xml] = LnxDb2Type.Xml,
             [Db2Type.Boolean] = LnxDb2Type.Boolean,
         }.ToFrozenDictionary();
+
+        static Db2TypeMapper()
+        {
+            var allValues = Enum.GetValues<Db2Type>();
+            foreach (var value in allValues)
+            {
+                if (!s_toWin.ContainsKey(value))
+                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Windows (OleDb) mapping in {nameof(Db2TypeMapper)}.");
+                if (!s_toLnx.ContainsKey(value))
+                    throw new InvalidOperationException($"Db2Type '{value}' is missing a Linux (IBM.Data.Db2) mapping in {nameof(Db2TypeMapper)}.");
+            }
+        }
 
         /// <summary>
         /// Converts a <see cref="Db2Type"/> to the corresponding <see cref="WinDb2Type"/>.

--- a/src/Ninja.Sharp.OpenDb2/Utilities/EnvironmentDetector.cs
+++ b/src/Ninja.Sharp.OpenDb2/Utilities/EnvironmentDetector.cs
@@ -6,8 +6,12 @@ using System.Runtime.InteropServices;
 
 namespace Ninja.Sharp.OpenDb2.Utilities
 {
+    /// <summary>
+    /// Default implementation of <see cref="IEnvironmentDetector"/> using <see cref="RuntimeInformation"/>.
+    /// </summary>
     public class EnvironmentDetector : IEnvironmentDetector
     {
+        /// <inheritdoc />
         public OSPlatform GetCurrentOSPlatform()
         {
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? OSPlatform.Windows :
@@ -16,11 +20,13 @@ namespace Ninja.Sharp.OpenDb2.Utilities
                    OSPlatform.Create("Other");
         }
 
+        /// <inheritdoc />
         public bool IsWindows()
         {
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         }
 
+        /// <inheritdoc />
         public bool IsLinux()
         {
             return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);


### PR DESCRIPTION
Building on the platform-agnostic Db2Type mapping and hardened parameter handling, this PR promotes CreateCommand(string, CommandType) and BeginTransaction() to the base IDb2Connection interface so consumers can work without depending on OS-specific interfaces. Also registers IDb2Connection in the DI container and adds unit tests for Db2TypeMapper, EnvironmentDetector, WinDb2Connection and WinDb2Command (~9% → ~52% coverage).