### PR TITLE
Hotfix libreria di riferimento per target 8.0

### DIFF
--- a/src/Ninja.Sharp.OpenDb2/Ninja.Sharp.OpenDb2.csproj
+++ b/src/Ninja.Sharp.OpenDb2/Ninja.Sharp.OpenDb2.csproj
@@ -10,10 +10,10 @@
 	<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 	<Company>The Sharp Ninjas</Company>
 	<Authors>The Sharp Ninjas</Authors>
-	<Version>1.3.0</Version>
-	<AssemblyVersion>1.3.0.0</AssemblyVersion>
-	<FileVersion>1.3.0.0</FileVersion>
-	<InformationalVersion>1.3.0</InformationalVersion>
+	<Version>1.3.1</Version>
+	<AssemblyVersion>1.3.1.0</AssemblyVersion>
+	<FileVersion>1.3.1.0</FileVersion>
+	<InformationalVersion>1.3.1</InformationalVersion>
     <RootNamespace>Ninja.Sharp.OpenDb2</RootNamespace>
 	<Description>A lightweight .NET client library that simplifies working with IBM DB2 databases</Description>
 	<PackageTags>DB2, OleDb, Sql</PackageTags>
@@ -55,7 +55,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="System.Data.OleDb" Version="8.0.1" />
-    <PackageReference Include="Net.IBM.Data.Db2-lnx" Version="9.0.0.400" />
+    <PackageReference Include="Net.IBM.Data.Db2-lnx" Version="8.0.0.500" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Downgrade libreria Net.IBM.Data.Db2-lnx alla versione 8.0.0.500 per target NET8 (tentativo di risoluzione incompatibilità licenza DB2)